### PR TITLE
Fixing bug in CSV reports when function alterNickName

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -2831,8 +2831,9 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
       return;
     }
     $contactID = $row['civicrm_contact_id'];
-    return "<div id=contact-{$contactID} class='crm-entity'>
-<span class='crm-editable crmf-nick_name crm-editable-enabled' data-action='create'>" . $value . "</span></div>";
+    return "<div id=contact-{$contactID} class='crm-entity'>" . 
+       "<span class='crm-editable crmf-nick_name crm-editable-enabled' data-action='create'>" . 
+       $value . "</span></div>";
   }
 
   /*


### PR DESCRIPTION
The return of function alterNickName (a string) 
includes a carriage return.  When that carriage return is converted 
to the CSV version of the report for download, the field 
then includes a carriage return, making 
it quite difficult to import and use this field in Excel.  In Excel 
the carriage returns come through as CHR(10) which is quite difficult 
to search/find/remove in an automated way.

The fix just breaks the string up so that the carriage return is 
removed and also so that future edits will be unlikely to
re-introduce it.
