### PR TITLE
Wrong name value for participant_event_id

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -3874,7 +3874,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
       ),
       'participant_event_id' => array(
         'title' => ts('Event ID'),
-        'name' => 'id',
+        'name' => 'event_id',
         'type' => CRM_Utils_Type::T_STRING,
         'alter_display' => 'alterEventID',
         'is_filters' => TRUE,


### PR DESCRIPTION
I was using the function getParticipantColumns for a custom report that extend RelationshipExtended report with participant filters. Since 2.1 update this report stop working filtering by event id. I think that this commit https://github.com/eileenmcnaughton/nz.co.fuzion.extendedreport/commit/655ec1bef29693b3b3b0c075bac14b140c34d843#diff-bfc47780dcc610e8169649bb84456669 caused the change.

This patch solves my issue but I don't know if it carries side effects.