### PR TITLE
show labels, not values for custom data fields on pivottables

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -3098,7 +3098,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
               }
             }
           }
-          if (substr($pivotRowField, 0, 7) == 'custom_' && $field == $pivotRowField) {
+          if (substr($pivotRowField, 0, 7) == 'custom_' && isset($specs['id']) && $specs['id'] == substr($pivotRowField, 7)) {
             $alterFunctions[$this->getPivotRowTableAlias() . '_' . $pivotRowField] = 'alterFromOptions';
             $alterMap[$this->getPivotRowTableAlias() . '_' . $pivotRowField] = $field;
             $alterSpecs[$this->getPivotRowTableAlias() . '_' . $pivotRowField] = $specs;


### PR DESCRIPTION
Line 3100 of ExtendedReport.php reads as follows:
```php
if (substr($pivotRowField, 0, 7) == 'custom_' && $field == $pivotRowField) {
```

$pivotRowField is the name of the pivot row field. $field is defined in a foreach, and is part of the metadata for the column.

When I select a custom field (ID of 67) for the pivot row, `$pivotRowField` is correctly set to `custom_67`. However, the corresponding `$field value` is `civicrm_contact_civicrm_value_individual_data_11custom_67`.

I'm not sure if the `$field` value is correct - clearly at some point it was meant to return `custom_67` - but I'd argue that the fact that this report works otherwise is an argument that this is correct.  So I've edited the conditional to expect the correct value.