### PR TITLE
Treat event start date as a date+time field, not a date field

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -4235,7 +4235,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
       ),
       'event_start_date' => array(
         'title' => ts('Event Start Date'),
-        'type' => CRM_Utils_Type::T_DATE,
+        'type' => CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME,
         'operatorType' => CRM_Report_Form::OP_DATE,
         'name' => 'start_date',
         'is_fields' => TRUE,


### PR DESCRIPTION
The dateClause method of `CRM_Report_Form` adds the time value on to a field - `000000` for the "from" date, `235959` to the "to" date.  However, it does NOT do that if the field type is T_DATE.  I'm adding T_DATE + T_TIME so that bitwise operations pick this up correctly, and searching date ranges in extended report filters now pick up events on the last day of a date range.