### PR TITLE
Add support for pre-constraining participant reports

### DIFF
--- a/CRM/Extendedreport/Form/Report/Event/EventPivot.php
+++ b/CRM/Extendedreport/Form/Report/Event/EventPivot.php
@@ -12,6 +12,7 @@ class CRM_Extendedreport_Form_Report_Event_EventPivot extends CRM_Extendedreport
   protected $isPivot = TRUE;
   protected $_rollup = 'WITH ROLLUP';
   public $_drilldownReport = array('event/participantlist' => 'Link to Participants');
+  protected $_participantTable = 'civicrm_participant';
   protected $_potentialCriteria = array(
     'rid',
     'sid',

--- a/CRM/Extendedreport/Form/Report/Event/ParticipantExtended.php
+++ b/CRM/Extendedreport/Form/Report/Event/ParticipantExtended.php
@@ -22,6 +22,7 @@ class CRM_Extendedreport_Form_Report_Event_ParticipantExtended extends CRM_Exten
   );
 
   public $_drilldownReport = array('event/income' => 'Link to Detail Report');
+  protected $_participantTable = 'civicrm_participant';
 
   /**
    * Class constructor.

--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -6079,8 +6079,12 @@ ON {$this->_aliases['civicrm_line_item']}.contid = {$this->_aliases['civicrm_con
   }
 
   function joinContactFromParticipant() {
-    $this->_from .= " LEFT JOIN civicrm_contact {$this->_aliases['civicrm_contact']}
-ON {$this->_aliases['civicrm_participant']}.contact_id = {$this->_aliases['civicrm_contact']}.id";
+    $this->_from .= "
+      LEFT JOIN {$this->_participantTable} cp ON cp.id = {$this->_aliases['civicrm_participant']}.id
+      LEFT JOIN civicrm_contact {$this->_aliases['civicrm_contact']}
+ON cp.contact_id = {$this->_aliases['civicrm_contact']}.id
+    ";
+
   }
 
   function joinContactFromMembership() {


### PR DESCRIPTION
"pre constraining" is a great feature.  I'm adding support for it to participant reports.

The use case I have is one that I'm not sure is universal, so this code isn't really doing anything here except making life easier for folks who want to customize participant reports.

The use case, FWIW - my client wants to see demograpghic data (stored in contact custom fields) for their participants - but they do NOT want someone who attended two events to be counted twice.  I suspect that some folks who use this behavior want to count folks twice, so this is a change that won't affect existing behavior.