### PR TITLE
Fix apostrophes breaking crm-editable

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -3461,7 +3461,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
             ));
             $options = $options['values'];
             $options['selected'] = $value;
-            $extra = "data-type='select' data-options='" . json_encode($options) . "'";
+            $extra = "data-type='select' data-options='" . json_encode($options, JSON_HEX_APOS) . "'";
             $value = $options[$value];
           }
           if (!empty($entity_field)) {


### PR DESCRIPTION
in formatCustomValues(), there's a bit of code that JSON encodes the options for multiple choice custom fields when the field is editable.  However, apostrophes are escaped incorrectly.  As a result, any select fields (and presumably checkboxes etc.) with an option including an apostrophe aren't editable.  When you try, they simply disappear.  To replicate the bug:

* Create a select box custom field.  Include an apostrophe in one or more enabled multiple choice options.
* Run a report that includes that field on a report that allows editing.
* When you click the field to edit it, it disappears rather than becomes editable.