### PR TITLE
Fix errant line breaks in CSV export of editable reports

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -6374,8 +6374,9 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
       $class = 'editable_select';
     }
     //nodeName == "INPUT" && this.type=="checkbox"
-    return "<div data-id='{$entityID}' data-entity='{$entity}' class='crm-entity'>
-    <span class='crm-editable crmf-{$specs['field_name']} $class ' data-action='create' $extra>" . $value . "</span></div>";
+    $editableDiv = "<div data-id='{$entityID}' data-entity='{$entity}' class='crm-entity'>" .
+      "<span class='crm-editable crmf-{$specs['field_name']} $class ' data-action='create' $extra>" . $value . "</span></div>";
+    return $editableDiv;
   }
 
   /*

--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -3466,8 +3466,8 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
           }
           if (!empty($entity_field)) {
             //$
-            $retValue = "<div id={$entity}-{$entityID} class='crm-entity'>
-          <span class='crm-editable crmf-custom_{$customField['id']} crm-editable' data-action='create' $extra >" . $value . "</span></div>";
+            $retValue = "<div id={$entity}-{$entityID} class='crm-entity'>" .
+              "<span class='crm-editable crmf-custom_{$customField['id']} crm-editable' data-action='create' $extra >" . $value . "</span></div>";
           }
           break;
         }


### PR DESCRIPTION
It's me again...

On "editable" reports, the HTML tags that wrap around alphanumeric text elements to make them editable has a line break between the `div` and `span`.  Which is more readable, and normally gets ignored, so it's fine..

However, when exporting to CSV, all that HTML is fed to `CRM_Report_Utils_Report::makeCsv`.  It's passed through this line to strip out HTML:
```
$value = str_replace('"', '""', html_entity_decode(strip_tags($value)));
```
Which strips the tags but not the line break, which ends up in those fields in your CSV.

LibreOffice merrily displays these fields with a line break in them - not ideal, but certainly better than Excel, which simply renders those fields as blanks.

Anyway - that's a lot of words to explain why I removed a line break from your code.

To replicate the bug, run a report (I used "Extended Report - Editable event Grid"), select one or more editable alphanumeric text fields, and export to CSV.  Open in a program that will render line breaks.