### PR TITLE
get rid of the db value separator before comparing to array

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -3243,6 +3243,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
    * @return string
    */
   function alterFromOptions($value, &$row, $selectedField, $criteriaFieldName, $specs) {
+    $value = trim($value, CRM_Core_DAO::VALUE_SEPARATOR);
     return CRM_Utils_Array::value($value, $specs['options']);
   }
 


### PR DESCRIPTION
fixes https://github.com/eileenmcnaughton/nz.co.fuzion.extendedreport/issues/78