### PR TITLE
Make indirect property evaluation PHP7-compatible

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -3166,7 +3166,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
     foreach ($rows as $index => & $row) {
       foreach ($row as $selectedField => $value) {
         if (array_key_exists($selectedField, $alterFunctions)) {
-          $rows[$index][$selectedField] = $this->$alterFunctions[$selectedField]($value, $row, $selectedField, $alterMap[$selectedField], $alterSpecs[$selectedField]);
+          $rows[$index][$selectedField] = $this->{$alterFunctions[$selectedField]}($value, $row, $selectedField, $alterMap[$selectedField], $alterSpecs[$selectedField]);
         }
       }
     }


### PR DESCRIPTION
Indirect property evaluation is handled differently in PHP7, so I'm making the desired behavior explicit:
http://php.net/manual/en/migration70.incompatible.php

Otherwise you get this error when running a report that calls this function:
```
Error: Function name must be a string in CRM_Extendedreport_Form_Report_ExtendedReport->alterDisplay() (line 3164 of /home/jon/local/civicrm-buildkit/build/dmaster/sites/default/files/civicrm/ext/nz.co.fuzion.extendedreport/CRM/Extendedreport/Form/Report/ExtendedReport.php).
```