### PR TITLE
initialize noFields for pivot reports

### DIFF
--- a/CRM/Extendedreport/Form/Report/ActivityPivot.php
+++ b/CRM/Extendedreport/Form/Report/ActivityPivot.php
@@ -13,6 +13,7 @@ class CRM_Extendedreport_Form_Report_ActivityPivot extends CRM_Extendedreport_Fo
   protected $_rollup = 'WITH ROLLUP';
   public $_drilldownReport = array();
   protected $_potentialCriteria = array();
+  protected $_noFields = TRUE;
 
   /**
    * Class constructor.

--- a/CRM/Extendedreport/Form/Report/Case/ActivityPivot.php
+++ b/CRM/Extendedreport/Form/Report/Case/ActivityPivot.php
@@ -14,6 +14,7 @@ class CRM_Extendedreport_Form_Report_Case_ActivityPivot extends CRM_Extendedrepo
   public $_drilldownReport = array();
   protected $_potentialCriteria = array();
   protected $isPivot = TRUE;
+  protected $_noFields = TRUE;
 
   /**
    * Class constructor.

--- a/CRM/Extendedreport/Form/Report/Case/CasePivot.php
+++ b/CRM/Extendedreport/Form/Report/Case/CasePivot.php
@@ -15,6 +15,7 @@ class CRM_Extendedreport_Form_Report_Case_CasePivot extends CRM_Extendedreport_F
   public $_drilldownReport = array();
   protected $_potentialCriteria = array();
   protected $isPivot = TRUE;
+  protected $_noFields = TRUE;
 
   /**
    * Class constructor.

--- a/CRM/Extendedreport/Form/Report/Case/CaseWithActivityPivot.php
+++ b/CRM/Extendedreport/Form/Report/Case/CaseWithActivityPivot.php
@@ -14,6 +14,7 @@ class CRM_Extendedreport_Form_Report_Case_CaseWithActivityPivot extends CRM_Exte
   protected $_aggregatesAddPercentage = TRUE;
   public $_drilldownReport = array();
   protected $isPivot = TRUE;
+  protected $_noFields = TRUE;
   /**
    * PreConstrain means the query gets run twice - the first time for generating temp tables
    * which go in the from the second time around

--- a/CRM/Extendedreport/Form/Report/Contact/Extendedcontact.php
+++ b/CRM/Extendedreport/Form/Report/Contact/Extendedcontact.php
@@ -11,6 +11,7 @@ class CRM_Extendedreport_Form_Report_Contact_Extendedcontact extends CRM_Extende
   protected $skipACL = TRUE;
   protected $_customGroupAggregates = TRUE;
   protected $isPivot = TRUE;
+  protected $_noFields = TRUE;
 
 
   /**

--- a/CRM/Extendedreport/Form/Report/Contribute/ContributionPivot.php
+++ b/CRM/Extendedreport/Form/Report/Contribute/ContributionPivot.php
@@ -13,6 +13,7 @@ class CRM_Extendedreport_Form_Report_Contribute_ContributionPivot extends CRM_Ex
   public $_drilldownReport = array();
   protected $isPivot = TRUE;
   protected $_potentialCriteria = array();
+  protected $_noFields = TRUE;
 
   /**
    * Class constructor.

--- a/CRM/Extendedreport/Form/Report/Event/EventPivot.php
+++ b/CRM/Extendedreport/Form/Report/Event/EventPivot.php
@@ -13,6 +13,7 @@ class CRM_Extendedreport_Form_Report_Event_EventPivot extends CRM_Extendedreport
   protected $_rollup = 'WITH ROLLUP';
   public $_drilldownReport = array('event/participantlist' => 'Link to Participants');
   protected $_participantTable = 'civicrm_participant';
+  protected $_noFields = TRUE;
   protected $_potentialCriteria = array(
     'rid',
     'sid',

--- a/CRM/Extendedreport/Form/Report/Member/MembershipPivot.php
+++ b/CRM/Extendedreport/Form/Report/Member/MembershipPivot.php
@@ -13,6 +13,7 @@ class CRM_Extendedreport_Form_Report_Member_MembershipPivot extends CRM_Extended
   protected $isPivot = TRUE;
   public $_drilldownReport = array('membership/membershipdetail' => 'Link to Participants');
   protected $_potentialCriteria = array();
+  protected $_noFields = TRUE;
 
   /**
    * Class constructor.


### PR DESCRIPTION
Pivot Reports doesn't contain any fields. Hence initialising this param so that $this->_params doesn't updates to NULL at https://github.com/civicrm/civicrm-core/blob/master/CRM/Report/Form.php#L2585-L2587 which doesn't let to create/save these reports.

Also added `type` for custom fields to remove e-notices caused by including custom fields in any of extended reports.