### PR TITLE
Fix group_concat with rollup to concat all the values in the last row

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -2992,6 +2992,16 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
       $this->assignSubTotalLines($rows);
     }
 
+    if (!empty($this->_rollup)) {
+      $lastIndex = key(array_slice($rows, -1, 1, TRUE));
+      //Do not concat non-stat field in the last row.
+      foreach ($rows[$lastIndex] as $key => &$val) {
+        if (!in_array($key, $this->_statFields)) {
+          $val = NULL;
+        }
+      }
+    }
+
     if (empty($rows)) {
       return;
     }


### PR DESCRIPTION
Fix for https://github.com/eileenmcnaughton/nz.co.fuzion.extendedreport/issues/81#issuecomment-290180500. It doesn't seems to be a latest regression, but a behavior of `rollup` of how it works with `group_concat`.

This replicate when we select a stat field to display in the result without grouping by the same set of select fields. Eg `line total`.

What happens is all other normal fields are selected as `group_concat` and the stat field gets calculated with `rollup`. As these stats are totaled at the bottom and `group_concat` appends all the values in the last row. Seems this is how `rollup` works.

I've also created a sample table to replicate this - from the doc - https://dev.mysql.com/doc/refman/5.7/en/group-by-modifiers.html 

    CREATE TABLE sales(year INT, country VARCHAR(20), product VARCHAR(32), profit INT);

After inserting some values - when we try to get the profit grouping by year(and also wish to see country) -

    SELECT GROUP_CONCAT(country) as Country, year, SUM(profit) AS profit
    FROM sales
    GROUP BY year ASC WITH ROLLUP; 

will output -

| Country  | year | profit |
| ------------- | ------------- |------------- |
| India,Australia  | 2014  |50  |
| New Zealand  | 2015  |20  |
| United States  | 2015  |150  |
| India,Australia,New Zealand,United States  | NULL  |220  |

There's no way to manipulate the query nullify the last row along with `rollup`. Either we need to remove rollup and use `union` or empty non-stat value in `alterDisplay()` as per changes made here. 