### PR TITLE
Add reportlet support.

### DIFF
--- a/CRM/Extendedreport/Form/Report/Contribute/Contributions.php
+++ b/CRM/Extendedreport/Form/Report/Contribute/Contributions.php
@@ -32,6 +32,22 @@
  */
 class CRM_Extendedreport_Form_Report_Contribute_Contributions extends CRM_Extendedreport_Form_Report_ExtendedReport {
 
+  /**
+   * Can this report be used on a contact tab.
+   *
+   * The report must support contact_id in the url for this to work.
+   *
+   * @var bool
+   */
+  protected $isSupportsContactTab = TRUE;
+
+  /**
+   * Support contact tabs by specifying which filter to map the contact id field to.
+   *
+   * @var string
+   */
+  protected $contactIDField = 'contribution_contact_id';
+
   protected $_baseTable = 'civicrm_contribution';
   /**
    * Class constructor.

--- a/CRM/Extendedreport/Form/Report/Price/Lineitemmembership.php
+++ b/CRM/Extendedreport/Form/Report/Price/Lineitemmembership.php
@@ -10,6 +10,15 @@ class CRM_Extendedreport_Form_Report_Price_Lineitemmembership extends CRM_Extend
 
   protected $_aclTable = 'civicrm_contact';
 
+  protected $isSupportsContactTab = TRUE;
+
+  /**
+   * Support contact tabs by specifying which filter to map the contact id field to.
+   *
+   * @var string
+   */
+  protected $contactIDField = 'membership_contact_id';
+
   /**
    * Class constructor.
    */

--- a/CRM/Extendedreport/Page/Inline/ExtendedReportlets.php
+++ b/CRM/Extendedreport/Page/Inline/ExtendedReportlets.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Created by IntelliJ IDEA.
+ * User: emcnaughton
+ * Date: 8/22/18
+ * Time: 4:43 PM
+ */
+class CRM_Extendedreport_Page_Inline_ExtendedReportlets {
+
+  public function run() {
+
+  }
+
+  /**
+   * Get reports configured for display
+   */
+  public static function getReportsToDisplay() {
+    $reportlets = Civi::cache()->get(__CLASS__ . 'contact_summary_reportlets');
+    if ($reportlets === NULL) {
+      $reportlets = civicrm_api3('ReportInstance', 'get', array('form_values' => array('LIKE' => '%contact_reportlet";s:1:"1";%')))['values'];
+      Civi::cache()->set(__CLASS__ . 'contact_summary_reportlets', $reportlets);
+    }
+    return $reportlets;
+  }
+
+  /**
+   * Clear report cache out.
+   */
+  public static function flushReports() {
+    Civi::cache()->set(__CLASS__ . 'contact_summary_reportlets', NULL);
+  }
+}

--- a/templates/CRM/Extendedreport/Page/Inline/ExtendedReport.tpl
+++ b/templates/CRM/Extendedreport/Page/Inline/ExtendedReport.tpl
@@ -1,0 +1,19 @@
+<table>
+  {crmAPI var='result' entity='ReportTemplate' action='getrows' instance_id=$blockVariables.id options=$apiOptions contact_id=$contactID}
+  <tr>
+    {assign var='metadata' value=$result.metadata}
+    {assign var='reportLabels' value=$metadata.labels}
+    {foreach from=$reportLabels item=header}
+      <th>{$header|escape}</th>
+    {/foreach}
+  </tr>
+  {foreach from=$result.values item=reportinstance}
+    <tr>
+    {foreach from=$reportinstance key=reportKey item=reportvalue}
+      {if $reportLabels.$reportKey}
+      <td>{$reportvalue|escape:purify}</td>
+      {/if}
+    {/foreach}
+    </tr>
+  {/foreach}
+</table>


### PR DESCRIPTION
This PR allows for 'reportlets' to be used as blocks on the contact summary screen (in conjunction with the contact layout editor). The reports are implicitly filtered to the current contact but can otherwise include additional filters & grouping etc that are saved into the reports

![screenshot 2018-08-23 22 03 47](https://user-images.githubusercontent.com/336308/44519197-7182f500-a720-11e8-8043-75fea4790e1f.png)


Enabled reports need to be saved as available. For reports where is is enabled the option can be seen on the report instance. WARNING - as of now you need to flush CiviCRM caches when you update this field on a report. There is a hook to do it but there is a bug on it in core.

![screenshot 2018-08-23 22 01 03](https://user-images.githubusercontent.com/336308/44519092-1b15b680-a720-11e8-9a7a-ced3ec8af1e5.png)

Currently enabled:
- Extended Report - Contributions
- Extended Report - Membership Price Set Report
-  Address History (Requires logging to be enabled)

Todo  - make column headers optional on the reportlets