### PR TITLE
Adding field: label from civicrm_line_item table.'

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -3335,6 +3335,12 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'is_fields' => TRUE,
         'is_filters' => TRUE,
       ),
+      'label' => array(
+        'title' => ts('Line Label'),
+        'type' => CRM_Utils_Type::T_STRING,
+        'is_fields' => TRUE,
+        'is_filters' => TRUE,
+      ),
       'tax_amount' => array(
         'title' => ts('Tax Amount'),
         'type' => CRM_Utils_Type::T_MONEY,


### PR DESCRIPTION
Adding field label from the civicrm_line_item table allows admins to search (i.e. filter) for Contacts, Contributions that have had a discount code applied to them - in the standard report environment so Actions (exports) as well as Add to Group are available out of the box. 

![image](https://user-images.githubusercontent.com/5340555/46736265-d7d2c100-cc55-11e8-91d9-ca9dfb2250b5.png)


