### PR TITLE
added non deductible amount

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -3240,6 +3240,15 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'is_fields' => TRUE,
         'is_filters' => TRUE,
       ),
+      'non_deductible_amount' => array(
+        'title' => ts('Non Deductible Amount'),
+        'type' => CRM_Utils_Type::T_MONEY,
+        'statistics' => array(
+          'sum' => ts('Non Deductible Total of Line Items')
+        ),
+        'is_fields' => TRUE,
+        'is_filters' => TRUE,
+      ),
     );
 
     return $this->buildColumns($specs, 'civicrm_line_item', 'CRM_Price_BAO_LineItem', NULL, $defaults);


### PR DESCRIPTION
I'm not sure how else to get this non deductible amount out of a
CiviCRM database. If you set a price set with a certain amount
that should be non-deductible, the line item table seems to be the
only place it is stored, yet it is not displayed any where else.