### PR TITLE
Add payment processor field to getFinancialTrxnColumns

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -3580,6 +3580,17 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'default' => TRUE,
         'type' => CRM_Utils_Type::T_STRING,
       ],
+      'payment_processor_id' => [
+        'title' => ts('Payment Processor'),
+        'alter_display' => 'alterPaymentProcessor',
+        'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+        'options' => CRM_Core_PseudoConstant::paymentProcessor(TRUE),
+        'type' => CRM_Utils_Type::T_INT,
+        'is_fields' => TRUE,
+        'is_filters' => TRUE,
+        'is_order_bys' => TRUE,
+        'is_group_bys' => TRUE,
+      ],
       'payment_instrument_id' => [
         'title' => ts('Payment Instrument'),
         'default' => TRUE,
@@ -6307,6 +6318,16 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
   function alterPaymentType($value) {
     $paymentInstruments = CRM_Contribute_PseudoConstant::paymentInstrument();
     return CRM_Utils_Array::value($value, $paymentInstruments);
+  }
+
+  /**
+   * @param int $value
+   *
+   * @return string
+   */
+  function alterPaymentProcessor($value) {
+    $paymentProcessors = CRM_Contribute_PseudoConstant::paymentProcessor(TRUE);
+    return CRM_Utils_Array::value($value, $paymentProcessors);
   }
 
   /**


### PR DESCRIPTION
Like it says on the tin.  See screenshots.

This seems to be something that others need too, which is why I'm upstreaming:
https://civicrm.stackexchange.com/questions/27695/report-with-payment-processor
https://civicrm.stackexchange.com/questions/21990/can-we-report-on-contributions-by-payment-processor

Before:
![Selection_873](https://user-images.githubusercontent.com/1796012/57549780-76c9b380-7332-11e9-8614-833bc42bb9c5.png)

After:
![Selection_872](https://user-images.githubusercontent.com/1796012/57549788-7b8e6780-7332-11e9-9465-6ef14b564d0c.png)
