### PR TITLE
Adding Primary Email column to report 'Extended Report - Price Set Line Items report'

### DIFF
--- a/CRM/Extendedreport/Form/Report/ColumnDefinitionTrait.php
+++ b/CRM/Extendedreport/Form/Report/ColumnDefinitionTrait.php
@@ -605,6 +605,11 @@ trait CRM_Extendedreport_Form_Report_ColumnDefinitionTrait {
     return $this->buildColumns($spec, $options['prefix'] . 'civicrm_contribution_recur', 'CRM_Contribute_BAO_ContributionRecur', NULL, $this->getDefaultsFromOptions($options), $options);
   }
 
+	/**
+	 * @param array $options
+	 *
+	 * @return mixed
+	 */
 	function getPrimaryEmailColumns($options = []) {
 		$defaultOptions = [
 			'prefix' => 'civicrm',

--- a/CRM/Extendedreport/Form/Report/ColumnDefinitionTrait.php
+++ b/CRM/Extendedreport/Form/Report/ColumnDefinitionTrait.php
@@ -605,4 +605,33 @@ trait CRM_Extendedreport_Form_Report_ColumnDefinitionTrait {
     return $this->buildColumns($spec, $options['prefix'] . 'civicrm_contribution_recur', 'CRM_Contribute_BAO_ContributionRecur', NULL, $this->getDefaultsFromOptions($options), $options);
   }
 
+	function getPrimaryEmailColumns($options = []) {
+		$defaultOptions = [
+			'prefix' => 'civicrm',
+			'prefix_label' => '',
+			'group_by' => FALSE,
+			'order_by' => TRUE,
+			'filters' => TRUE,
+			'fields_defaults' => [],
+			'filters_defaults' => [],
+			'group_bys_defaults' => [],
+			'order_by_defaults' => [],
+		];
+		$options = array_merge($defaultOptions, $options);
+		$defaults = $this->getDefaultsFromOptions($options);
+
+		$fields = [
+			'email' => [
+				'title' => ts($options['prefix_label'] . 'Primary Email'),
+				'name' => 'email',
+				'is_fields' => TRUE,
+				'is_filters' => TRUE,
+				'is_group_bys' => TRUE,
+				'is_order_bys' => TRUE,
+				'type' => CRM_Utils_Type::T_STRING,
+				'operatorType' => CRM_Report_Form::OP_STRING,
+			],
+		];
+		return $this->buildColumns($fields, $options['prefix'] . 'civicrm_email', 'CRM_Core_DAO_Email', NULL, $defaults, $options);
+	}
 }

--- a/CRM/Extendedreport/Form/Report/ColumnDefinitionTrait.php
+++ b/CRM/Extendedreport/Form/Report/ColumnDefinitionTrait.php
@@ -605,38 +605,4 @@ trait CRM_Extendedreport_Form_Report_ColumnDefinitionTrait {
     return $this->buildColumns($spec, $options['prefix'] . 'civicrm_contribution_recur', 'CRM_Contribute_BAO_ContributionRecur', NULL, $this->getDefaultsFromOptions($options), $options);
   }
 
-	/**
-	 * @param array $options
-	 *
-	 * @return mixed
-	 */
-	function getPrimaryEmailColumns($options = []) {
-		$defaultOptions = [
-			'prefix' => 'civicrm',
-			'prefix_label' => '',
-			'group_by' => FALSE,
-			'order_by' => TRUE,
-			'filters' => TRUE,
-			'fields_defaults' => [],
-			'filters_defaults' => [],
-			'group_bys_defaults' => [],
-			'order_by_defaults' => [],
-		];
-		$options = array_merge($defaultOptions, $options);
-		$defaults = $this->getDefaultsFromOptions($options);
-
-		$fields = [
-			'email' => [
-				'title' => ts($options['prefix_label'] . 'Primary Email'),
-				'name' => 'email',
-				'is_fields' => TRUE,
-				'is_filters' => TRUE,
-				'is_group_bys' => TRUE,
-				'is_order_bys' => TRUE,
-				'type' => CRM_Utils_Type::T_STRING,
-				'operatorType' => CRM_Report_Form::OP_STRING,
-			],
-		];
-		return $this->buildColumns($fields, $options['prefix'] . 'civicrm_email', 'CRM_Core_DAO_Email', NULL, $defaults, $options);
-	}
 }

--- a/CRM/Extendedreport/Form/Report/Price/Lineitem.php
+++ b/CRM/Extendedreport/Form/Report/Price/Lineitem.php
@@ -45,6 +45,10 @@ class CRM_Extendedreport_Form_Report_Price_Lineitem extends CRM_Extendedreport_F
   public function __construct() {
     $this->_columns
       = $this->getColumns('Contact', array('order_by' => TRUE))
+      + $this->getColumns('PrimaryEmail', [
+		    'fields' => TRUE,
+		    'order_by' => FALSE,
+	    ])
       + $this->getColumns('Event')
       + $this->getColumns('Participant')
       + $this->getColumns('Contribution', array('order_by' => TRUE))
@@ -81,6 +85,7 @@ class CRM_Extendedreport_Form_Report_Price_Lineitem extends CRM_Extendedreport_F
       'event_from_participant',
       'address_from_contact',
       'address_from_contribution',
+	    'email_from_contact',
     );
 
   }

--- a/CRM/Extendedreport/Form/Report/Price/Lineitem.php
+++ b/CRM/Extendedreport/Form/Report/Price/Lineitem.php
@@ -45,7 +45,7 @@ class CRM_Extendedreport_Form_Report_Price_Lineitem extends CRM_Extendedreport_F
   public function __construct() {
     $this->_columns
       = $this->getColumns('Contact', array('order_by' => TRUE))
-      + $this->getColumns('PrimaryEmail', [
+      + $this->getColumns('Email', [
 		    'fields' => TRUE,
 		    'order_by' => FALSE,
 	    ])

--- a/CRM/Extendedreport/Form/Report/Price/Lineitem.php
+++ b/CRM/Extendedreport/Form/Report/Price/Lineitem.php
@@ -46,9 +46,10 @@ class CRM_Extendedreport_Form_Report_Price_Lineitem extends CRM_Extendedreport_F
     $this->_columns
       = $this->getColumns('Contact', array('order_by' => TRUE))
       + $this->getColumns('Email', [
-		    'fields' => TRUE,
-		    'order_by' => FALSE,
-	    ])
+          'fields' => TRUE,
+          'order_by' => FALSE,
+        ]
+      )
       + $this->getColumns('Event')
       + $this->getColumns('Participant')
       + $this->getColumns('Contribution', array('order_by' => TRUE))


### PR DESCRIPTION
### Before
Users cannot add Primary Email column to the report 'Extended Report - Price Set Line Items report'.
### After
Primary Email appears in the selection and Primary Email column in the report displays the primary email of the contact.
### Note
Using function getPrimaryEmailColumns instead of getEmailColumns, because the original function raises an error when querying database.


Agileware Ref: CIVICRM-1199