### PR TITLE
apply rollup for statistics

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -1023,7 +1023,7 @@ class CRM_Extendedreport_Form_Report_ExtendedReport extends CRM_Report_Form {
           $this->_groupBy .= ", " . $section['dbAlias'];
         }
       }
-      if (!empty($this->_statFields) && empty($this->_orderByArray) &&
+      if (!empty($this->_statistics) && empty($this->_orderByArray) &&
         (count($this->_groupByArray) <= 1 || !$this->_having)
         && $this->_rollup !== FALSE
         && !$this->isInProcessOfPreconstraining()


### PR DESCRIPTION
If you select columns like line item totals, then the results will be rolled up
This is _Price Lineitem_ report and column chosen is _Line Total_

Before

![before](https://user-images.githubusercontent.com/3455173/58465180-c1319980-8154-11e9-877a-9c0283262b45.png)

After
![after](https://user-images.githubusercontent.com/3455173/58465194-c68ee400-8154-11e9-93d1-b886797458cf.png)
