### PR TITLE
Add address location type join fitler to line item membership report

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -4707,6 +4707,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
    *  - prefix_label Label to give columns from this address table instance
    *
    * @return array address columns definition
+   * @throws \CRM_Core_Exception
    */
   function getAddressColumns($options = []) {
     $defaultOptions = [
@@ -4907,7 +4908,9 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'title' => ts($options['prefix_label'] . 'Location Type'),
         'type' => CRM_Utils_Type::T_INT,
         'is_fields' => TRUE,
+        'is_join_filters' => TRUE,
         'alter_display' => 'alterLocationTypeID',
+        'options' => CRM_Core_BAO_Address::buildOptions('location_type_id'),
       ],
       $options['prefix'] . 'id' => [
         'title' => ts($options['prefix_label'] . ' Address ID'),

--- a/CRM/Extendedreport/Form/Report/Price/Lineitemmembership.php
+++ b/CRM/Extendedreport/Form/Report/Price/Lineitemmembership.php
@@ -11,6 +11,7 @@ class CRM_Extendedreport_Form_Report_Price_Lineitemmembership extends CRM_Extend
   protected $_aclTable = 'civicrm_contact';
 
   protected $isSupportsContactTab = TRUE;
+  protected $joinFiltersTab = TRUE;
 
   /**
    * Support contact tabs by specifying which filter to map the contact id field to.
@@ -29,7 +30,7 @@ class CRM_Extendedreport_Form_Report_Price_Lineitemmembership extends CRM_Extend
     $this->getColumns('PriceField') +
     $this->getColumns('PriceFieldValue') +
     $this->getColumns('LineItem') +
-    $this->getColumns('Address');
+    $this->getColumns('Address', ['join_filters' => TRUE]);
 
     parent::__construct();
   }


### PR DESCRIPTION
Adds join filter on location_type_id to line item membership report - this allows only certain addresses to be included (as opposed to the main filter which would only include contacts with those addresses)

<img width="1150" alt="Screen Shot 2019-06-14 at 8 31 38 AM" src="https://user-images.githubusercontent.com/336308/59509388-e0cc0000-8e7e-11e9-87cf-4e25c49387ce.png">
