### PR TITLE
Fix summary  fields on custom data

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -425,6 +425,7 @@ class CRM_Extendedreport_Form_Report_ExtendedReport extends CRM_Report_Form {
    * (not in core) for uniquename matching against core metadata.
    *
    * https://github.com/eileenmcnaughton/nz.co.fuzion.extendedreport/issues/12
+   * @throws \Exception
    */
   public function preProcess() {
     $this->preProcessCommon();
@@ -7442,16 +7443,29 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
     $curFields[$fieldName] = $field;
 
     // Add totals field
+    $this->_columns[$tableKey]['metadata'][$fieldName . '_qty'] = array_merge(
+      $field, [
+        'title' => "$prefixLabel{$field['label']} Count of Selected",
+        'statistics' => ['count' => "$prefixLabel{$field['label']} Count of Selected"],
+        'is_group_bys' => FALSE,
+        'is_order_bys' => FALSE,
+        'is_filters' => FALSE,
+        'is_join_filters' => FALSE,
+      ]
+    );
     if ($curFields[$fieldName]['type'] === CRM_Utils_Type::T_INT) {
-      $this->_columns[$tableKey]['metadata'][$fieldName . '_qty'] = array_merge(
+      $this->_columns[$tableKey]['metadata'][$fieldName . '_sum'] = array_merge(
         $field, [
-          'title' => "$prefixLabel{$field['label']} Quantity",
-          'statistics' => ['count' => ts("Quantity Selected")],
+          'title' => "$prefixLabel{$field['label']} Selected Quantity",
+          'statistics' => ['sum' => "$prefixLabel{$field['label']} Selected Quantity"],
+          'is_group_bys' => FALSE,
+          'is_order_bys' => FALSE,
+          'is_filters' => FALSE,
+          'is_join_filters' => FALSE,
         ]
       );
     }
   }
-
 
   /**
    * @param array $field


### PR DESCRIPTION
Per https://github.com/eileenmcnaughton/nz.co.fuzion.extendedreport/issues/270#issuecomment-509217743 some
quantity fields that were in some cases useful were removed in
https://github.com/eileenmcnaughton/nz.co.fuzion.extendedreport/commit/5c027fb48572379d259d651f2e6285e36f8f9fdc

When I look at the screenshot provided I see
1) that the qty fields were available in group bys as well as fields - which seems misleading
2) they were describing something as quantity that seemed not to truly be quanitity
& this misleadingness was probably why it was removed.

I re-instated it for all fields as an available field ( but removed them from the other tabs for all fields)
but changed the name to be Count of Selected - which is  more clunky but more accurate.

For boolean & integer fields I additionally added an extra 'Selected Quantity' which is a sum of
the selected amounts (I'm a bit on the fence about doing that instead of count or as well)