### PR TITLE
add owner membership as a filter

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -3501,6 +3501,11 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'name' => 'contact_id',
         'is_filters' => TRUE,
       ],
+      'owner_membership_id' => [
+        'title' => ts('Primary Membership'),
+        'operatorType' => CRM_Report_Form::OP_INT,
+        'is_filters' => TRUE,
+      ],
     ];
     return $this->buildColumns($specs, $options['prefix'] . 'civicrm_membership', 'CRM_Member_DAO_Membership');
   }


### PR DESCRIPTION
No way to identify whether the membership is primary or inherited

After patch can search on primary/inherited
![mem_filter](https://user-images.githubusercontent.com/3455173/61687781-d7b53500-ad40-11e9-96d1-d0e486a0e507.png)
