### PR TITLE
 Mysql 8 compliance - remove SQL_CALC_FOUND_ROWS #275

### DIFF
--- a/CRM/Extendedreport/Form/Report/Contribute/DetailExtended.php
+++ b/CRM/Extendedreport/Form/Report/Contribute/DetailExtended.php
@@ -92,7 +92,8 @@ class CRM_Extendedreport_Form_Report_Contribute_DetailExtended extends CRM_Exten
         'is_aggregate_columns' => FALSE,
         'is_aggregate_rows' => FALSE,
         'type' => CRM_Utils_Type::T_INT,
-        'alias' => 'cordinality_cordinality'
+        'alias' => 'cordinality_cordinality',
+        'table_key' => 'civicrm_contribution',
       ]],
       'group_title' => ts('Contribution Ordinality'),
 

--- a/CRM/Extendedreport/Form/Report/Contribute/DetailExtended.php
+++ b/CRM/Extendedreport/Form/Report/Contribute/DetailExtended.php
@@ -419,10 +419,6 @@ WHERE  civicrm_contribution_contribution_id={$row['civicrm_contribution_contribu
     }
 
     if (!empty($this->_sections)) {
-      // build the query with no LIMIT clause
-      $select = str_ireplace('SELECT SQL_CALC_FOUND_ROWS ', 'SELECT ', $this->_select);
-      $sql = "{$select} {$this->_from} {$this->_where} {$this->_groupBy} {$this->_having} {$this->_orderBy}";
-
       // pull section aliases out of $this->_sections
       $sectionAliases = array_keys($this->_sections);
 

--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -2524,8 +2524,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
 
     if (!empty($this->_sections)) {
       // build the query with no LIMIT clause
-      $select = str_ireplace('SELECT SQL_CALC_FOUND_ROWS ', 'SELECT ', $this->_select);
-      $sql = "{$select} {$this->_from} {$this->_where} {$this->_groupBy} {$this->_having} {$this->_orderBy}";
+      $sql = "{$this->_select} {$this->_from} {$this->_where} {$this->_groupBy} {$this->_having} {$this->_orderBy}";
 
       // pull section aliases out of $this->_sections
       $sectionAliases = array_keys($this->_sections);

--- a/CRM/Extendedreport/Form/Report/Pledge/Btbns.php
+++ b/CRM/Extendedreport/Form/Report/Pledge/Btbns.php
@@ -54,6 +54,7 @@ class CRM_Extendedreport_Form_Report_Pledge_Btbns extends CRM_Extendedreport_For
       'is_group_bys' => FALSE,
       'is_order_bys' => FALSE,
       'default' => date('Y'),
+      'table_key' => 'civicrm_pledge',
     ];
     $this->_groupFilter = TRUE;
     $this->_tagFilter = TRUE;

--- a/CRM/Extendedreport/Form/Report/Pledge/Btbns.php
+++ b/CRM/Extendedreport/Form/Report/Pledge/Btbns.php
@@ -167,7 +167,7 @@ class CRM_Extendedreport_Form_Report_Pledge_Btbns extends CRM_Extendedreport_For
     $rows = $contactIds = array();
     if (!CRM_Utils_Array::value('charts', $this->_params)) {
       $this->limit();
-      $getContacts = "SELECT SQL_CALC_FOUND_ROWS {$this->_aliases['civicrm_contact']}.id as cid {$this->_from} {$this->_where}  GROUP BY {$this->_aliases['civicrm_contact']}.id {$this->_limit}";
+      $getContacts = "SELECT {$this->_aliases['civicrm_contact']}.id as cid {$this->_from} {$this->_where}  GROUP BY {$this->_aliases['civicrm_contact']}.id {$this->_limit}";
       $dao = CRM_Core_DAO::executeQuery($getContacts);
       while ($dao->fetch()) {
         $contactIds[] = $dao->cid;

--- a/CRM/Extendedreport/Form/Report/Pledge/Lybuns.php
+++ b/CRM/Extendedreport/Form/Report/Pledge/Lybuns.php
@@ -74,6 +74,7 @@ class CRM_Extendedreport_Form_Report_Pledge_Lybuns extends CRM_Extendedreport_Fo
       'is_order_bys' => FALSE,
       'is_aggregate_columns' => FALSE,
       'is_aggregate_rows' => FALSE,
+      'table_key' => 'civicrm_pledge',
     ];
     $this->_groupFilter = TRUE;
     $this->_tagFilter = TRUE;
@@ -257,11 +258,10 @@ class CRM_Extendedreport_Form_Report_Pledge_Lybuns extends CRM_Extendedreport_Fo
 
       while ($dao->fetch()) {
 
-        if (!$dao->civicrm_pledge_contact_id) {
+        if (empty($dao->civicrm_pledge_contact_id)) {
           continue;
         }
 
-        $row = array();
         foreach ($this->_columnHeaders as $key => $value) {
           if (property_exists($dao, $key)) {
             $rows[$dao->civicrm_pledge_contact_id][$key] = $dao->$key;

--- a/CRM/Extendedreport/Form/Report/Pledge/Lybuns.php
+++ b/CRM/Extendedreport/Form/Report/Pledge/Lybuns.php
@@ -231,7 +231,7 @@ class CRM_Extendedreport_Form_Report_Pledge_Lybuns extends CRM_Extendedreport_Fo
     $rows = $contactIds = array();
     if (!CRM_Utils_Array::value('charts', $this->_params)) {
       $this->limit();
-      $getContacts = "SELECT SQL_CALC_FOUND_ROWS {$this->_aliases['civicrm_contact']}.id as cid {$this->_from} {$this->_where}  GROUP BY {$this->_aliases['civicrm_contact']}.id {$this->_limit}";
+      $getContacts = "SELECT {$this->_aliases['civicrm_contact']}.id as cid {$this->_from} {$this->_where}  GROUP BY {$this->_aliases['civicrm_contact']}.id {$this->_limit}";
 
       $dao = CRM_Core_DAO::executeQuery($getContacts);
 
@@ -286,8 +286,6 @@ class CRM_Extendedreport_Form_Report_Pledge_Lybuns extends CRM_Extendedreport_Fo
 
     // do print / pdf / instance stuff if needed
     $this->endPostProcess($rows);
-
-
   }
 
   /**

--- a/CRM/Extendedreport/Form/Report/Pledge/Lybunt.php
+++ b/CRM/Extendedreport/Form/Report/Pledge/Lybunt.php
@@ -235,7 +235,7 @@ class CRM_Extendedreport_Form_Report_Pledge_Lybunt extends CRM_Extendedreport_Fo
     $rows = $contactIds = array();
     if (!CRM_Utils_Array::value('charts', $this->_params)) {
       $this->limit();
-      $getContacts = "SELECT SQL_CALC_FOUND_ROWS {$this->_aliases['civicrm_contact']}.id as cid {$this->_from} {$this->_where}  GROUP BY {$this->_aliases['civicrm_contact']}.id {$this->_limit}";
+      $getContacts = "SELECT {$this->_aliases['civicrm_contact']}.id as cid {$this->_from} {$this->_where}  GROUP BY {$this->_aliases['civicrm_contact']}.id {$this->_limit}";
 
       $dao = CRM_Core_DAO::executeQuery($getContacts);
 

--- a/CRM/Extendedreport/Form/Report/Pledge/Lybunt.php
+++ b/CRM/Extendedreport/Form/Report/Pledge/Lybunt.php
@@ -74,6 +74,7 @@ class CRM_Extendedreport_Form_Report_Pledge_Lybunt extends CRM_Extendedreport_Fo
       'is_fields' => FALSE,
       'is_group_bys' => FALSE,
       'is_order_bys' => FALSE,
+      'table_key' => 'civicrm_pledge',
     ];
 
     $this->_groupFilter = TRUE;

--- a/CRM/Extendedreport/Form/Report/Pledge/Sybuns.php
+++ b/CRM/Extendedreport/Form/Report/Pledge/Sybuns.php
@@ -258,7 +258,7 @@ class CRM_Extendedreport_Form_Report_Pledge_Sybuns extends CRM_Extendedreport_Fo
     $rows = $contactIds = array();
     if (!CRM_Utils_Array::value('charts', $this->_params)) {
       $this->limit();
-      $getContacts = "SELECT SQL_CALC_FOUND_ROWS {$this->_aliases['civicrm_contact']}.id as cid {$this->_from} {$this->_where} GROUP BY {$this->_aliases['civicrm_contact']}.id {$this->_limit}";
+      $getContacts = "SELECT {$this->_aliases['civicrm_contact']}.id as cid {$this->_from} {$this->_where} GROUP BY {$this->_aliases['civicrm_contact']}.id {$this->_limit}";
 
       $dao = CRM_Core_DAO::executeQuery($getContacts);
 

--- a/CRM/Extendedreport/Form/Report/Pledge/Sybuns.php
+++ b/CRM/Extendedreport/Form/Report/Pledge/Sybuns.php
@@ -72,6 +72,7 @@ class CRM_Extendedreport_Form_Report_Pledge_Sybuns extends CRM_Extendedreport_Fo
       'is_order_bys' => FALSE,
       'is_aggregate_columns' => FALSE,
       'is_aggregate_rows' => FALSE,
+      'table_key' => 'civicrm_pledge',
     ];
     $this->_tagFilter = TRUE;
     parent::__construct();

--- a/CRM/Extendedreport/Form/Report/Pledge/Sybunt.php
+++ b/CRM/Extendedreport/Form/Report/Pledge/Sybunt.php
@@ -218,7 +218,7 @@ class CRM_Extendedreport_Form_Report_Pledge_Sybunt extends CRM_Extendedreport_Fo
     $rows = $contactIds = array();
     if (!CRM_Utils_Array::value('charts', $this->_params)) {
       $this->limit();
-      $getContacts = "SELECT SQL_CALC_FOUND_ROWS {$this->_aliases['civicrm_contact']}.id as cid {$this->_from} {$this->_where} GROUP BY {$this->_aliases['civicrm_contact']}.id {$this->_limit}";
+      $getContacts = "SELECT {$this->_aliases['civicrm_contact']}.id as cid {$this->_from} {$this->_where} GROUP BY {$this->_aliases['civicrm_contact']}.id {$this->_limit}";
 
       $dao = CRM_Core_DAO::executeQuery($getContacts);
 

--- a/CRM/Extendedreport/Form/Report/Pledge/Sybunt.php
+++ b/CRM/Extendedreport/Form/Report/Pledge/Sybunt.php
@@ -73,6 +73,7 @@ class CRM_Extendedreport_Form_Report_Pledge_Sybunt extends CRM_Extendedreport_Fo
       'is_fields' => FALSE,
       'is_group_bys' => FALSE,
       'is_order_bys' => FALSE,
+      'table_key' => 'civicrm_pledge',
     ];
 
     $this->_groupFilter = TRUE;


### PR DESCRIPTION
Per the issue mysql 8 doesn't support sql_calc_round_rows.

All usages seem to be in kinda old unloved reports & no achieving anything AFAIK so lets' just kill