### PR TITLE
getContributionColumns: add thankyou_date

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -4327,6 +4327,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'is_order_bys' => TRUE,
       ],
       'receipt_date' => ['is_fields' => TRUE, 'is_order_bys' => TRUE,],
+      'thankyou_date' => ['is_fields' => TRUE, 'is_order_bys' => TRUE,'is_filters' => TRUE],
       'total_amount' => [
         'title' => ts('Contribution Amount'),
         'statistics' => [


### PR DESCRIPTION
This adds the "Thank you date" to the contribution report.

Since we cannot use the Find Contribution screen to find un-thanked contributions, my client uses the Line Item report to find any donations that may have not been thanked (ex: a donation attached to an event registration).