### PR TITLE
Fix display of disabled custom field options on reports

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -7996,8 +7996,8 @@ WHERE cg.extends IN ('" . $extendsString . "') AND
       if (empty($spec['option_group_id'])) {
         throw new Exception('currently column headers need to be radio or select');
       }
-      $options = civicrm_api('option_value', 'get', [
-        'version' => 3,
+      $options = civicrm_api3('option_value', 'get', [
+        'is_active' => 1,
         'options' => ['limit' => 50,],
         'option_group_id' => $spec['option_group_id'],
       ]);


### PR DESCRIPTION
Disabled custom field options are listed in reports. Added filter to only fetch active options.

Report -

![image](https://user-images.githubusercontent.com/5929648/64777667-5af04b80-d578-11e9-8cae-3f298466fbd8.png)

The above custom fields are disabled

![image](https://user-images.githubusercontent.com/5929648/64777776-98ed6f80-d578-11e9-80c5-e55791847db0.png)
