### PR TITLE
grant report support

### DIFF
--- a/CRM/Extendedreport/Form/Report/ColumnDefinitionTrait.php
+++ b/CRM/Extendedreport/Form/Report/ColumnDefinitionTrait.php
@@ -620,4 +620,106 @@ trait CRM_Extendedreport_Form_Report_ColumnDefinitionTrait {
     return $this->buildColumns($spec, $options['prefix'] . 'civicrm_contribution_recur', 'CRM_Contribute_BAO_ContributionRecur', NULL, $this->getDefaultsFromOptions($options), $options);
   }
 
+  /**
+   * Function to get Grant columns.
+   *
+   * @param array $options column options
+   *
+   * @return array
+   */
+  protected function getGrantColumns($options = []) {
+    $defaultOptions = [
+      'prefix' => '',
+      'prefix_label' => '',
+      'group_by' => FALSE,
+      'order_by' => TRUE,
+      'filters' => TRUE,
+      'fields_defaults' => [],
+      'filters_defaults' => [],
+      'group_bys_defaults' => [],
+      'order_by_defaults' => ['sort_name ASC'],
+    ];
+
+    $options = array_merge($defaultOptions, $options);
+    $defaults = $this->getDefaultsFromOptions($options);
+    $specs = [
+      'grant_type_id' => [
+        'title' => ts('Grant Type'),
+        'is_fields' => 1,
+        'is_filters' => 1,
+        'is_group_bys' => 1,
+        'is_order_bys' => 1,
+        'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+        'options' => CRM_Core_PseudoConstant::get('CRM_Grant_DAO_Grant', 'grant_type_id'),
+        'alter_display' => 'alterPseudoConstant',
+      ],
+      'status_id' => [
+        'title' => ts('Grant Status'),
+        'is_fields' => 1,
+        'is_filters' => 1,
+        'is_group_bys' => 1,
+        'is_order_bys' => 1,
+        'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+        'options' => CRM_Core_PseudoConstant::get('CRM_Grant_DAO_Grant', 'status_id'),
+        'alter_display' => 'alterPseudoConstant',
+      ],
+      'amount_total' => [
+        'title' => ts('Amount Requested'),
+        'type' => CRM_Utils_Type::T_MONEY,
+        'is_fields' => 1,
+        'is_filters' => 1,
+        'is_order_bys' => 1,
+      ],
+      'amount_granted' => [
+        'title' => ts('Amount Granted'),
+        'is_fields' => 1,
+        'is_filters' => 1,
+        'is_order_bys' => 1,
+      ],
+      'application_received_date' => [
+        'title' => ts('Application Received'),
+        'default' => TRUE,
+        'type' => CRM_Utils_Type::T_DATE,
+        'is_fields' => 1,
+        'is_filters' => 1,
+        'is_group_bys' => 1,
+        'is_order_bys' => 1,
+      ],
+      'money_transfer_date' => [
+        'title' => ts('Money Transfer Date'),
+        'type' => CRM_Utils_Type::T_DATE,
+        'is_fields' => 1,
+        'is_filters' => 1,
+        'is_group_bys' => 1,
+        'is_order_bys' => 1,
+      ],
+      'grant_due_date' => [
+        'title' => ts('Grant Report Due'),
+        'type' => CRM_Utils_Type::T_DATE,
+        'is_fields' => 1,
+        'is_filters' => 1,
+        'is_group_bys' => 1,
+        'is_order_bys' => 1,
+      ],
+      'decision_date' => [
+        'title' => ts('Grant Decision Date'),
+        'type' => CRM_Utils_Type::T_DATE,
+        'is_fields' => 1,
+        'is_filters' => 1,
+        'is_group_bys' => 1,
+        'is_order_bys' => 1,
+      ],
+      'rationale' => [
+        'title' => ts('Rationale'),
+        'is_fields' => 1,
+      ],
+      'grant_report_received' => [
+        'title' => ts('Grant Report Received'),
+        'is_fields' => 1,
+        'is_filters' => 1,
+      ],
+    ];
+    return $this->buildColumns($specs, 'civicrm_grant', 'CRM_Grant_BAO_Grant', 'grants', $defaults);
+  }
+
 }

--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -5432,6 +5432,11 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'rightTable' => 'civicrm_note',
         'callback' => 'joinNoteFromParticipant',
       ],
+      'contact_from_grant' => [
+        'leftTable' => 'civicrm_grant',
+        'rightTable' => 'civicrm_contact',
+        'callback' => 'joinContactFromGrant',
+],
     ];
   }
 
@@ -5978,6 +5983,11 @@ ON {$this->_aliases['civicrm_participant']}.contact_id = {$this->_aliases['civic
   function joinNoteFromParticipant() {
     $this->_from .= " LEFT JOIN civicrm_note {$this->_aliases['civicrm_note']}
 ON {$this->_aliases['civicrm_participant']}.id = {$this->_aliases['civicrm_note']}.entity_id";
+  }
+
+  function joinContactFromGrant() {
+    $this->_from .= "LEFT JOIN civicrm_contact {$this->_aliases['civicrm_contact']}
+ON {$this->_aliases['civicrm_contact']}.id = {$this->_aliases['civicrm_grant']}.contact_id";
   }
 
   function joinContactFromMembership() {
@@ -6827,7 +6837,7 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
     if (!isset($table['alias'])) {
       $this->_columns[$tableName]['alias'] = substr($tableName, 8) .
         '_civireport';
-    }
+      }
     else {
       $this->_columns[$tableName]['alias'] = $table['alias'];
     }
@@ -7825,7 +7835,7 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
       if (in_array($extendsEntity, [
         'Individual',
         'Household',
-        'Organziation',
+        'Organization',
       ])) {
         $extendsEntities['Contact'] = TRUE;
         unset($extendsEntities[$extendsEntity]);

--- a/CRM/Extendedreport/Form/Report/Grant/Detail.mgd.php
+++ b/CRM/Extendedreport/Form/Report/Grant/Detail.mgd.php
@@ -1,0 +1,19 @@
+<?php
+// This file declares a managed database record of type "ReportTemplate".
+// The record will be automatically inserted, updated, or deleted from the
+// database as appropriate. For more details, see "hook_civicrm_managed" at:
+// http://wiki.civicrm.org/confluence/display/CRMDOC42/Hook+Reference
+return array(
+  0 => array(
+    'name' => 'Extended Report - Grant Detail',
+    'entity' => 'ReportTemplate',
+    'params' => array(
+      'version' => 3,
+      'label' => 'Extended Report - Grant Detail',
+      'description' => 'Extended Report - Grant Detail',
+      'class_name' => 'CRM_Extendedreport_Form_Report_Grant_Detail',
+      'report_url' => 'grant/detailextended',
+      'component' => 'CiviGrant',
+    ),
+  ),
+);

--- a/CRM/Extendedreport/Form/Report/Grant/Detail.php
+++ b/CRM/Extendedreport/Form/Report/Grant/Detail.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2010
+ *            $Id$
+ *
+ */
+
+class CRM_Extendedreport_Form_Report_Grant_Detail extends CRM_Extendedreport_Form_Report_ExtendedReport {
+
+  protected $_customGroupExtends = [
+    'Contact',
+    'Individual',
+    'Household',
+    'Organization',
+    'Grant',
+  ];
+  protected $_baseTable = 'civicrm_grant';
+  protected $_customGroupGroupBy = TRUE;
+
+  /**
+   * Class constructor.
+   */
+  public function __construct() {
+    $this->_columns = $this->getColumns('Contact') + $this->getColumns('Email') + $this->getColumns('Phone') + $this->getColumns('Grant');
+
+    parent::__construct();
+    CRM_Core_DAO::disableFullGroupByMode();
+  }
+
+  function fromClauses() {
+    return [
+    'contact_from_grant',
+    'email_from_contact',
+    'phone_from_contact',
+    ];
+  }
+
+}


### PR DESCRIPTION
This adds support for grant reports to Extended Report.  I've also included a clone of the existing Grant Detail report, but I can leave that out if you feel that creates a support burden.  I've done my best to use all the modernizations of Extended Report (e.g. `fromClauses()` not `from()`, define `alter_display` callbacks in column definitions).

My end goal is a custom report that uses grants as a base table, but I thought I'd give a vanilla implementation of the Detail report so the new metadata could be adequately looked at.