### PR TITLE
'Link to Detail Report' now works with Financial Type

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -6274,7 +6274,7 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
       $url = CRM_Report_Utils_Report::getNextUrl(key($this->_drilldownReport),
         "reset=1&force=1&{$criteriaQueryParams}&" .
         "{$criteriaFieldName}_op=in&{$criteriaFieldName}_value={$value}",
-        $this->_absoluteUrl, $this->_id
+        $this->_absoluteUrl, $this->_id, $this->_drilldownReport
       );
       $row[$selectedField . '_link'] = $url;
     }


### PR DESCRIPTION
"Link to Detail Report" wasn't working with Financial Types.  This is because an argument wasn't being passed to `getNextUrl()` in `alterFinancialType()`. You can see the fifth argument passed in `alterEventID()`.  

To replicate this most easily, create a new report of type "Extended Report - Contributions Overview", and display (and group by) financial type.  The "Link to Detail Report" value is ignored.  After this patch is applied, "Link to Detail Report" is respected.

This particular report also doesn't respect "Link to Detail Report" when grouping by contact ID, for different reasons.  I don't need this, but in the course of troubleshooting I developed a patch.  Once I test it, I'll submit that separately.