### PR TITLE
'Link to Detail Report' on contact ID now works on Contribution Overv…

### DIFF
--- a/CRM/Extendedreport/Form/Report/Contribute/Overview.php
+++ b/CRM/Extendedreport/Form/Report/Contribute/Overview.php
@@ -466,15 +466,13 @@ ROUND(AVG({$this->_aliases['civicrm_contribution_soft']}.amount), 2) as civicrm_
       }
 
       // convert display name to links
-      if (array_key_exists('civicrm_contact_sort_name', $row) &&
-        array_key_exists('civicrm_contact_id', $row)
+      if (array_key_exists('civicrm_contact_civicrm_contact_display_name', $row) &&
+      array_key_exists('civicrm_contact_civicrm_contact_contact_id', $row)
       ) {
-        $url = CRM_Report_Utils_Report::getNextUrl('contribute/detail',
-          'reset=1&force=1&id_op=eq&id_value=' . $row['civicrm_contact_id'],
-          $this->_absoluteUrl, $this->_id, $this->_drilldownReport
+        $url = CRM_Report_Utils_Report::getNextUrl('contribution/detailextended', 'reset=1&force=1&id_op=eq&id_value=' . $row['civicrm_contact_civicrm_contact_contact_id'], $this->_absoluteUrl, $this->_id, $this->_drilldownReport
         );
-        $rows[$rowNum]['civicrm_contact_sort_name_link'] = $url;
-        $rows[$rowNum]['civicrm_contact_sort_name_hover'] = ts("Lists detailed contribution(s) for this record.");
+        $rows[$rowNum]['civicrm_contact_civicrm_contact_display_name_link'] = $url;
+        $rows[$rowNum]['civicrm_contact_civicrm_contact_display_name_hover'] = ts("Lists detailed contribution(s) for this record.");
         $entryFound = TRUE;
       }
 


### PR DESCRIPTION
…iew report

This looks like a bit of copy/paste from elsewhere - the field names were wrong and the report name should be `contribution/detailextended` not `contribute/detail`, but the logic is correct.  Changing the element names fixes this.

Easiest way to test is to create a Contribution Overview report that displays contact ID and contact name, and groups by contact ID, and has "Link to Detail Report" set.  Without this patch, "Link to Detail Report" is ignored; with the patch, it's respected.