### PR TITLE
Port core#655 to Extended Reports

### DIFF
--- a/CRM/Extendedreport/Form/Report/Contribute/DetailExtended.php
+++ b/CRM/Extendedreport/Form/Report/Contribute/DetailExtended.php
@@ -78,6 +78,7 @@ class CRM_Extendedreport_Form_Report_Contribute_DetailExtended extends CRM_Exten
     $this->_columns['civicrm_contribution']['fields']['id']['required'] = TRUE;
     $this->_columns['civicrm_contribution']['fields']['currency']['required'] = TRUE;
     $this->_columns['civicrm_contribution']['fields']['currency']['no_display'] = TRUE;
+    $this->_columns['civicrm_contribution']['metadata']['contribution_total_amount']['statistics'] = [];
 
     $this->_columns['civicrm_contribution_ordinality'] = [
       'dao' => 'CRM_Contribute_DAO_Contribution',


### PR DESCRIPTION
Well, this bug sent me on an Extended Reports [yak shaving](https://www.hanselman.com/blog/YakShavingDefinedIllGetThatDoneAsSoonAsIShaveThisYak.aspx) expedition - but the original bug is here, and is simple.

#### The Bug
When your Contribution Details Extended report joins to a table via a one-to-many relationship, your contributions are multiplied by the number of records you're joining to.  This is identical to [core#655](https://lab.civicrm.org/dev/core/issues/655), which is the same bug in core Contribution Details.

Note that while core#655 says this happens when joining to soft credits, it happens in other scenarios too - in my case, by joining to a multi-record custom field group.

#### Steps to replicate
* Create a new multi-record custom field group and a single field.
* Give a contact a contribution, and fill in at least two records of the multi-record custom field.
* Go to Contribution Details Extended, and on `Fields`, include the multi-record custom field.

#### Actual Result
The contribution amount (and number of contributions) is multiplied by the number of multi-record custom fields.

#### Expected Result
The contribution amount should match the `total_amount` of the contribution as recorded.

#### Caveat 1
Note that this doesn't fix the statistics section, which is also wrong in core.  Once my core fix (https://github.com/civicrm/civicrm-core/pull/15435) is merged, we can port that to Extended Report.

#### Caveat 2
This doesn't fix the report on its own - you must also group by Contribution ID.  I believe that grouping by Contribution ID should be a default in this report - I expect that in this report, 1 row always corresponds to one contribution.

