### PR TITLE
"group by defaults" doesn't work

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -3373,6 +3373,9 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
           $columns[$tableName][$type][$fieldAlias] = $spec;
           if (isset($defaults[$type . '_defaults']) && isset($defaults[$type . '_defaults'][$spec['name']])) {
             $columns[$tableName]['metadata'][$fieldAlias]['default'] = $defaults[$type . '_defaults'][$spec['name']];
+            if ($type == 'group_bys') {
+              $columns[$tableName]['metadata'][$fieldAlias]['is_group_bys_default'] = $defaults[$type . '_defaults'][$spec['name']];
+            }
           }
         }
       }


### PR DESCRIPTION
In Contribution Details Extended, there's [this line](https://github.com/eileenmcnaughton/nz.co.fuzion.extendedreport/blob/502fdb7e4e652f74bb457a6be1469efe51bf6f7d/CRM/Extendedreport/Form/Report/Contribute/DetailExtended.php#L75):
```php
 'group_bys_defaults' => ['id' => TRUE],
```

You'd expect that this would set the "Contribution ID" field to true by default on the `Grouping` tab, but you'd be wrong.  Until now.

#### Steps to replicate
* Create a new report instance with the Contribution Details Extended template.
* Look at the `Grouping` tab.  No checkbox next to Contribution ID.

After the patch is applied, the field is checked by default.