### PR TITLE
Don't loop through setDefaultValues code unnecessarily

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -1479,6 +1479,7 @@ class CRM_Extendedreport_Form_Report_ExtendedReport extends CRM_Report_Form {
           }
         }
       }
+    }
 
       foreach ($this->getMetadataByType('group_bys') as $fieldName => $field) {
         if (isset($field['is_group_bys_default'])) {
@@ -1551,7 +1552,6 @@ class CRM_Extendedreport_Form_Report_ExtendedReport extends CRM_Report_Form {
           }
         }
       }
-    }
 
     if (!empty($this->_submitValues)) {
       $this->preProcessOrderBy($this->_submitValues);


### PR DESCRIPTION
While debugging the last two PRs, I found this bug.  In `setDefaultValues()` you loop through the metadata a few times.  That's fine.  However, some of the loops are incorrectly nested in the first loop.  The return value is the same, but it obviously takes much longer.

I'm taking advantage of the lack of lint checking on this repo (and the fact that it's not 100% style compliant already) to move the curly brace without un-indenting, so this PR doesn't look like a huge mess.  If this gets merged, I can do a style-only followup.

N.b. you can look at `setDefaultValues()` in core's `CRM/Report/Form.php` for comparison, the code more closely matches what I'm doing here than what it is currently.