### PR TITLE
Fix tab weight not being set for reportlets

### DIFF
--- a/extendedreport.php
+++ b/extendedreport.php
@@ -114,9 +114,9 @@ function extendedreport_civicrm_tabset($tabsetName, &$tabs, $context) {
           'output' => 'html',
           'force' => 1,
           'section' => 2,
-          'weight' => 70,
         ]
       ),
+      'weight' => 70,
     ];
   }
 }


### PR DESCRIPTION
This fixes an issue where the tab weight for reportlets is not set in the menu hook, causing weird tab sorting in some scenarios where other extensions use the same hook.

The code already attempts to set the weight, but does so in the URL array rather than the outer menu array.