### PR TITLE
Soft Credit metadata

### DIFF
--- a/CRM/Extendedreport/Form/Report/ColumnDefinitionTrait.php
+++ b/CRM/Extendedreport/Form/Report/ColumnDefinitionTrait.php
@@ -621,6 +621,58 @@ trait CRM_Extendedreport_Form_Report_ColumnDefinitionTrait {
   }
 
   /**
+   * Function to get ContributionSoft columns
+   * @param array $options
+   *
+   * @return array
+   */
+  function getContributionSoftColumns($options = []) {
+    $spec = [
+      'id' => [
+        'is_fields' => FALSE,
+        'is_filters' => FALSE,
+        'type' => CRM_Utils_Type::T_INT,
+        'is_order_bys' => FALSE,
+      ],
+      'contribution_id' => [
+        'is_fields' => FALSE,
+        'is_filters' => FALSE,
+        'type' => CRM_Utils_Type::T_INT,
+        'is_order_bys' => FALSE,
+        'default' => TRUE,
+      ],
+      'amount' => [
+        'default' => TRUE,
+        'type' => CRM_Utils_Type::T_MONEY,
+        'is_fields' => TRUE,
+        'is_filters' => TRUE,
+        'is_group_bys' => TRUE,
+        'is_order_bys' => TRUE,
+      ],
+      'soft_credit_type_id' => [
+        'is_fields' => TRUE,
+        'is_filters' => TRUE,
+        'is_group_bys' => TRUE,
+        'type' => CRM_Utils_Type::T_INT,
+        'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+        'options' => CRM_Contribute_BAO_ContributionSoft::buildOptions('soft_credit_type_id'),
+        'alter_display' => 'alterPseudoConstant',
+        'is_order_bys' => TRUE,
+      ],
+      'currency' => [
+        'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+        'options' => CRM_Core_OptionGroup::values('currencies_enabled'),
+        'default' => NULL,
+        'type' => CRM_Utils_Type::T_STRING,
+        'is_fields' => TRUE,
+        'is_filters' => TRUE,
+        'is_order_bys' => TRUE,
+      ],
+    ];
+    return $this->buildColumns($spec, $options['prefix'] . 'civicrm_contribution_soft', 'CRM_Contribute_BAO_ContributionSoft', NULL, $this->getDefaultsFromOptions($options), $options);
+  }
+
+  /**
    * Function to get Grant columns.
    *
    * @param array $options column options

--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -5327,6 +5327,11 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'rightTable' => 'civicrm_contact',
         'callback' => 'joinContactFromContributionRecur',
       ],
+      'contribution_from_contribution_soft' => [
+        'leftTable' => 'civicrm_contribution_soft',
+        'rightTable' => 'civicrm_contact',
+        'callback' => 'joinContributionFromContributionSoft',
+      ],
       'contact_from_pledge' => [
         'leftTable' => 'civicrm_pledge',
         'rightTable' => 'civicrm_contact',
@@ -6007,6 +6012,14 @@ ON {$this->_aliases['civicrm_contribution']}.contact_id = {$this->_aliases['civi
   function joinContactFromContributionRecur() {
     $this->_from .= " LEFT JOIN civicrm_contact {$this->_aliases['civicrm_contact']}
 ON {$this->_aliases['civicrm_contribution_recur']}.contact_id = {$this->_aliases['civicrm_contact']}.id";
+  }
+
+  /**
+   * Join contribution in from civicrm_contribution_soft table.
+   */
+  function joinContributionFromContributionSoft() {
+    $this->_from .= " LEFT JOIN civicrm_contribution {$this->_aliases['civicrm_contribution']}
+ON {$this->_aliases['civicrm_contribution_soft']}.contribution_id = {$this->_aliases['civicrm_contribution']}.id";
   }
 
   /**


### PR DESCRIPTION
Since soft credits are (thankfully) no longer part of the Contribution Details Extended report, it's helpful to have a Soft Credit Extended report.  I just wrote one.

I'm not sure if you want this report in Extended Report proper or a separate extension, and I also need more user testing before I consider my report ready for submission.  However, the metadata component of it is complete, and I imagine that even if you don't want the report in Extended Report, you probably do want this metadata.