### PR TITLE
[Closes #327] Allow a required field to be optionally displayed

### DIFF
--- a/CRM/Extendedreport/Form/Report/ActivityEditable.php
+++ b/CRM/Extendedreport/Form/Report/ActivityEditable.php
@@ -30,8 +30,7 @@ class CRM_Extendedreport_Form_Report_ActivityEditable extends CRM_Extendedreport
   public function __construct() {
     $this->_columns = $this->getColumns('Activity', ['fields_defaults' => ['activity_type_id', 'details', 'subject']])
       + $this->getColumns('Contact', ['prefix' => 'target_']);
-    $this->_columns['civicrm_activity']['metadata']['activity_id']['required'] = TRUE;
-    $this->_columns['civicrm_activity']['metadata']['activity_id']['no_display'] = TRUE;
+    $this->_columns['civicrm_activity']['metadata']['activity_id']['required_sql'] = TRUE;
     parent::__construct();
   }
 

--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -668,6 +668,7 @@ class CRM_Extendedreport_Form_Report_ExtendedReport extends CRM_Report_Form {
     $this->unsetBaseTableStatsFieldsWhereNoGroupBy();
 
     $selectedFields = $this->getSelectedFields();
+    $configuredFields = $this->getConfiguredFieldsFlatArray();
 
     $select = [];
     // Where we need fields for a having clause & the are not selected we
@@ -693,6 +694,12 @@ class CRM_Extendedreport_Form_Report_ExtendedReport extends CRM_Report_Form {
 
     foreach ($selectedFields as $fieldName => $field) {
       $this->addAdditionalRequiredFields($field, $field['table_name']);
+
+      // Only display required_sql field as column if selected from UI.
+      if (!empty($field['required_sql']) && !array_key_exists($fieldName, $configuredFields)) {
+        $this->_noDisplay[] = $field['table_name'] . '_' . $fieldName;
+      }
+
       $tableName = $field['table_name'];
       $alias = isset($field['alias']) ? $field['alias'] : "{$tableName}_{$fieldName}";
       $fieldStats = $this->getFieldStatistics($field);
@@ -2734,9 +2741,7 @@ LEFT JOIN civicrm_contact {$prop['alias']} ON {$prop['alias']}.id = {$this->_ali
     // unset columns not to be displayed.
     if (!empty($rows)) {
       foreach ($this->_noDisplay as $noDisplayField) {
-        foreach ($rows as $rowNum => $row) {
-          unset($this->_columnHeaders[$noDisplayField]);
-        }
+        unset($this->_columnHeaders[$noDisplayField]);
       }
     }
 
@@ -7621,7 +7626,7 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
 
     $orderBys = $this->getSelectedOrderBys();
     foreach ($fields as $fieldName => $field) {
-      if (!empty($field['required'])) {
+      if (!empty($field['required']) || !empty($field['required_sql'])) {
         $selectedFields[$fieldName] = $field;
       }
 


### PR DESCRIPTION
Currently, if you specify a field as both `required` = `TRUE` and `no_display` = `TRUE`, then the field is required in SQL, but the UI checkbox to display the field doesn't work.  You can see this in the Editable Activities report screenshot below.

This PR defines a new `required_sql` spec, which indicates that a field is always required for SQL, but it's up to the user whether to display the column in results.

If this is merged, there are a number of places where we can go through and fix reports.  E.g. it's common to set `contact_id` to be required to allow `alterDisplayName()` to link to the contact record - but this prevents displaying the Contact ID in the report.

**Before**
![Selection_762](https://user-images.githubusercontent.com/1796012/71692967-4a5b1f80-2d79-11ea-8a8a-923f70daa8d3.png)
**After**
![Selection_763](https://user-images.githubusercontent.com/1796012/71692973-4f1fd380-2d79-11ea-8d0b-6a148aa3b6bd.png)
