### PR TITLE
Fix participant extended report when no related contact selected

### DIFF
--- a/CRM/Extendedreport/Form/Report/Event/ParticipantExtended.php
+++ b/CRM/Extendedreport/Form/Report/Event/ParticipantExtended.php
@@ -121,15 +121,18 @@ class CRM_Extendedreport_Form_Report_Event_ParticipantExtended extends CRM_Exten
    * @return array
    */
   public function fromClauses() {
-    return [
+    $fromClauses = [
       'event_from_participant',
       'contact_from_participant',
       'note_from_participant',
       'phone_from_contact',
       'address_from_contact',
       'email_from_contact',
-      'related_contact_from_participant',
     ];
+    if ($this->isTableSelected('related_civicrm_contact')) {
+      $fromClauses[] = 'related_contact_from_participant';
+    }
+    return $fromClauses;
   }
 
   /**


### PR DESCRIPTION
I found and fixed this bug while doing some unrelated testing a few weeks ago, I noticed the uncommitted fix in my repo today.

When you run the Extended Participants report, you get duplicate rows when the contact has multiple relationships.  This is probably expected behavior if you're displaying relationship data, but not otherwise.  See screenshots (all settings on tabs other than "Columns" are default):

**Before**
![Selection_769](https://user-images.githubusercontent.com/1796012/71697477-19cdb280-2d86-11ea-95e8-67e7c21426bc.png)

**After**
![Selection_768](https://user-images.githubusercontent.com/1796012/71697492-20f4c080-2d86-11ea-93e1-bf4b275a66d2.png)
