### PR TITLE
Add "Addressee", "Postal Greeting" and "Email Greeting" as available columns (which can be used to filter and order by)

### DIFF
--- a/CRM/Extendedreport/Form/Report/ColumnDefinitionTrait.php
+++ b/CRM/Extendedreport/Form/Report/ColumnDefinitionTrait.php
@@ -358,6 +358,27 @@ trait CRM_Extendedreport_Form_Report_ColumnDefinitionTrait {
         'is_filters' => TRUE,
         'is_group_bys' => TRUE,
       ],
+      $options['prefix'] . 'email_greeting_display' => [
+        'name' => 'email_greeting_display',
+        'title' => E::ts($options['prefix_label'] . 'Email Greeting'),
+        'is_fields' => TRUE,
+        'is_filters' => TRUE,
+        'is_order_bys' => TRUE,
+      ],
+      $options['prefix'] . 'postal_greeting_display' => [
+        'name' => 'postal_greeting_display',
+        'title' => E::ts($options['prefix_label'] . 'Postal Greeting'),
+        'is_fields' => TRUE,
+        'is_filters' => TRUE,
+        'is_order_bys' => TRUE,
+      ],
+      $options['prefix'] . 'addressee_display' => [
+        'name' => 'addressee_display',
+        'title' => E::ts($options['prefix_label'] . 'Addressee'),
+        'is_fields' => TRUE,
+        'is_filters' => TRUE,
+        'is_order_bys' => TRUE,
+      ],
     ];
     $individualFields = [
       $options['prefix'] . 'first_name' => [


### PR DESCRIPTION
Adds three "Communication Preference" fields  to the Columns -> Contact Section:
+ Addressee
+ Postal Greeting
+ Email Greeting

When checked these fields are included as columns. They can also be used to filter or order by.

See Screenshot below:
![exportScreen](https://user-images.githubusercontent.com/11323624/73008893-7b110080-3ddd-11ea-9219-c5241aba1cf7.png)
