### PR TITLE
Ensure that for the contribution pivot report returns a grand total r…

### DIFF
--- a/CRM/Extendedreport/Form/Report/Contribute/ContributionPivot.php
+++ b/CRM/Extendedreport/Form/Report/Contribute/ContributionPivot.php
@@ -46,6 +46,8 @@ class CRM_Extendedreport_Form_Report_Contribute_ContributionPivot extends CRM_Ex
           'fields' => FALSE,
           'aggregate_rows' => TRUE,
         ]);
+    // Ensure that a grand total result shows even if rows returned are more than 50 as this report doesn't do paging.
+    $this->setAddPaging(FALSE);
     parent::__construct();
   }
 


### PR DESCRIPTION
…ow even if over 50 rows are returned

This does so by specifically saying we are not doing paging which is implied by the use of ROLLUP