### PR TITLE
don't extend a second entity if we're not joining to the second entity

### DIFF
--- a/CRM/Extendedreport/Form/Report/Event/ParticipantExtended.php
+++ b/CRM/Extendedreport/Form/Report/Event/ParticipantExtended.php
@@ -129,7 +129,9 @@ class CRM_Extendedreport_Form_Report_Event_ParticipantExtended extends CRM_Exten
       'address_from_contact',
       'email_from_contact',
     ];
-    if ($this->isTableSelected('related_civicrm_contact')) {
+    if ($this->isTableSelected('related_civicrm_contact') ||
+        $this->isTableSelected('related_civicrm_email') ||
+        $this->isTableSelected('related_civicrm_phone')) {
       $fromClauses[] = 'related_contact_from_participant';
     }
     return $fromClauses;

--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -2427,7 +2427,7 @@ class CRM_Extendedreport_Form_Report_ExtendedReport extends CRM_Report_Form {
   public function extendedCustomDataFrom() {
     foreach ($this->getMetadataByType('metadata') as $prop) {
       $table = $prop['table_name'];
-      if (empty($prop['extends']) || !$this->isCustomTableSelected($table)) {
+      if (empty($prop['extends']) || !$this->isCustomTableSelected($table) || !$this->isTableSelected($prop['extends_table'])) {
         continue;
       }
 


### PR DESCRIPTION
Some jerk (me) caused a regression with #332.

The Participant Extended Report adds a "related contact" to the report - and #332 fixed some incorrect results by not joining the related contact table if no related contact fields were selected.

However, ` CRM_Extendedreport_Form_Report_ExtendedReport::extendedCustomDataFrom()`, whose docblock reads, `Overridden to support custom data for multiple entities of the same type`, tries to join the custom field tables for the related contact regardless.  So if you try to include custom fields (on the primary contact), you get the error `Database Error Code: Unknown column 'related_civicrm_contact.id' in 'on clause', 1054`.

The solution is to check if the table the custom field extends is actually selected, and if not, skip adding it.

This revealed a follow-on bug - adding a related contact's email or phone fields without adding any contact fields would cause the same error.  So I fixed that in the ParticipantExtended report.