### PR TITLE
Closes #366: Fix 'field not found' error when using a pivot table with a custom field

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -2422,12 +2422,18 @@ class CRM_Extendedreport_Form_Report_ExtendedReport extends CRM_Report_Form {
   /**
    * Build custom data from clause.
    *
-   * Overridden to support custom data for multiple entities of the same type.
+   * Overridden to support custom data for multiple entities of the same type and pivot fields.
    */
   public function extendedCustomDataFrom() {
-    foreach ($this->getMetadataByType('metadata') as $prop) {
+    $pivotColumn = $this->_params['aggregate_column_headers'] ?? NULL;
+    $rowColumn = $this->_params['aggregate_row_headers'] ?? NULL;
+    foreach ($this->getMetadataByType('metadata') as $fieldName => $prop) {
       $table = $prop['table_name'];
-      if (empty($prop['extends']) || !$this->isCustomTableSelected($table)) {
+      if (empty($prop['extends']) ||
+          !$this->isCustomTableSelected($table) ||
+          !$this->isTableSelected($prop['extends_table']) &&
+          ($pivotColumn !== $fieldName && $rowColumn !== $fieldName)
+      ) {
         continue;
       }
 


### PR DESCRIPTION
This is pretty straightforward - it looks bigger than it is because I reformatted the last `if` statement for readability.  Replication steps are on #366.

Note that in an ideal world, this code probably would go into `CRM_Report_Form::selectedTables()` so it's picked up by the existing call to `$this->isTableSelected()`, but that change doesn't make sense in core, and this feels too minor to override the existing method.