### PR TITLE
fix crm-editable when the entity's primary key is aliased

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -3106,8 +3106,14 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
       $entity_table = $this->_aliases[strtolower('civicrm_' . $entity)];
       $idKeyArray = [$entity_table . '.id'];
       if (empty($this->_groupByArray) || $this->_groupByArray == $idKeyArray) {
-        $entity_field = $entity_table . '_id';
-        $entityID = $row[$this->getMetadataByType('fields')[$entity_field]['alias']];
+        foreach ($this->getMetadataByType('fields') as $fieldName => $field) {
+          if ($field['name'] === 'id') {
+            $entity_field = $fieldName;
+            $alias = $field['alias'];
+            break;
+          }
+        }
+        $entityID = $row[$alias];
       }
     }
     if (CRM_Utils_System::isNull($value) && !in_array($customField['data_type'], [


### PR DESCRIPTION
When running some reports (e.g. "Editable Events"), the custom (and other?) fields aren't editable, and you get a bunch of "undefined index" errors.  To replicate, create some event custom fields and include them in the Editable Event report.

The cause is that `CRM_Extendedreport_Form_Report_ExtendedReport::formatCustomValues()` attempts to discover the entity ID by making assumptions that the keys `object->metadata['fields']` follow a pattern of `$table_name . '_id'`.  However, in the case of fields with unique names, this isn't true; e.g. we search for `civicrm_event_id` when we need `civicrm_event_event_id`.

I fix this by explicitly comparing against the `name` element of the array rather than the key of the array.