### PR TITLE
enable search based on whether it's a primary or inherited membership

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -7774,6 +7774,9 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
     $filters = $this->getMetadataByType('filters');
     foreach ($this->_params as $key => $value) {
       $field = '';
+      if ($key == 'membership_owner_membership_id_op') {
+        $key = 'membership_owner_membership_id_value';
+      }
       if (substr($key, -6, 6) === '_value' && ($value !== '' && $value !== NULL && $value !== "NULL" && $value !== [])) {
         $field = substr($key, 0, strlen($key) - 6);
       }


### PR DESCRIPTION
This filter is exposed in the UI, but using it has no effect because
the filter is not properly picked up.

This PR is a bit hacky, but I just couldn't figure out a more elegant
way to handle it since the search itself doesn't fit any defined
patterns in CiviReport.