### PR TITLE
ENH Extension of the lineitemmembership witg paymentplan issues

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -4722,6 +4722,51 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
     return $this->buildColumns($spec, 'civicrm_pledge', 'CRM_Pledge_DAO_Pledge');
   }
 
+  
+  /**
+   * Show empty columns.
+   *
+   * @param array $options
+   *
+   * @return array
+   */
+  function getEmptyColumns($options = []) {
+   
+    $options = array_merge(['group_title' => E::ts('Empty')], $options);
+      
+      
+    $options = array_merge($defaultOptions, $options);
+      
+    $fields = [
+      'Empty1' => [
+        'title' => ts('Empty1'),
+        'name' => 'Empty1',
+        'is_fields' => TRUE,
+        'type' => CRM_Utils_Type::T_STRING,  
+      ],
+      'Empty2' => [
+        'title' => ts('Empty2'),
+        'name' => 'Empty2',
+        'is_fields' => TRUE,
+        'type' => CRM_Utils_Type::T_STRING,  
+      ],
+      'Empty3' => [
+        'title' => ts('Empty3'),
+        'name' => 'Empty3',
+        'is_fields' => TRUE,
+        'type' => CRM_Utils_Type::T_STRING,  
+      ],
+      'Empty4' => [
+        'title' => ts('Empty4'),
+        'name' => 'Empty4',
+        'is_fields' => TRUE,
+        'type' => CRM_Utils_Type::T_STRING,  
+      ],
+    ];
+    return $this->buildColumns($fields, 'Empty');
+  }
+  
+  
   /**
    * Get email columns.
    *

--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -3620,6 +3620,36 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'is_group_bys' => TRUE,
         'operator' => 'like',
       ],
+      'is_active' => [
+        'title' => ts('Active'),
+        'name' => 'is_active',
+        'type' => CRM_Utils_Type::T_BOOLEAN,
+        'is_fields' => TRUE,
+        'is_filters' => TRUE,
+        'is_order_bys' => FALSE,
+        'is_group_bys' => FALSE,
+        'options' => [
+        '' => ts('- select -'),
+        1 => ts('Yes'),
+        0 => ts('No'),
+      ],
+      ],
+      'active_on' => [
+        'name' => 'active_on',
+        'is_fields' => TRUE,
+        'is_filters' => TRUE,
+        'title' => ts('Active on'),
+        'type' => CRM_Utils_Type::T_DATE,
+        'operatorType' => CRM_Report_Form::OP_DATE,
+      ],
+      'expire_on' => [
+        'name' => 'expire_on',
+        'is_fields' => TRUE,
+        'is_filters' => TRUE,
+        'title' => ts('Expire on'),
+        'type' => CRM_Utils_Type::T_DATE,
+        'operatorType' => CRM_Report_Form::OP_DATE,
+      ],
     ];
     return $this->buildColumns($specs, 'civicrm_price_field', 'CRM_Price_BAO_PriceField');
   }

--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -4768,32 +4768,32 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
     $options = array_merge($defaultOptions, $options);
       
     $fields = [
-      'Empty1' => [
-        'title' => ts('Empty1'),
-        'name' => 'Empty1',
+      'EMPTY1' => [
+        'title' => ts('EMPTY1'),
+        'name' => 'EMPTY1',
         'is_fields' => TRUE,
         'type' => CRM_Utils_Type::T_STRING,  
       ],
-      'Empty2' => [
-        'title' => ts('Empty2'),
-        'name' => 'Empty2',
+      'EMPTY2' => [
+        'title' => ts('EMPTY2'),
+        'name' => 'EMPTY2',
         'is_fields' => TRUE,
         'type' => CRM_Utils_Type::T_STRING,  
       ],
-      'Empty3' => [
-        'title' => ts('Empty3'),
-        'name' => 'Empty3',
+      'EMPTY3' => [
+        'title' => ts('EMPTY3'),
+        'name' => 'EMPTY3',
         'is_fields' => TRUE,
         'type' => CRM_Utils_Type::T_STRING,  
       ],
-      'Empty4' => [
-        'title' => ts('Empty4'),
-        'name' => 'Empty4',
+      'EMPTY4' => [
+        'title' => ts('EMPTY4'),
+        'name' => 'EMPTY4',
         'is_fields' => TRUE,
         'type' => CRM_Utils_Type::T_STRING,  
       ],
     ];
-    return $this->buildColumns($fields, 'Empty');
+    return $this->buildColumns($fields, 'EMPTY');
   }
   
   

--- a/CRM/Extendedreport/Form/Report/Price/Lineitem.php
+++ b/CRM/Extendedreport/Form/Report/Price/Lineitem.php
@@ -33,7 +33,7 @@
  */
 class CRM_Extendedreport_Form_Report_Price_Lineitem extends CRM_Extendedreport_Form_Report_ExtendedReport {
 
-  protected $_customGroupExtends = ['Contribution'];
+  protected $_customGroupExtends = ['Contribution', 'Individual', 'Contact'];
 
   protected $_baseTable = 'civicrm_line_item';
 
@@ -57,11 +57,15 @@ class CRM_Extendedreport_Form_Report_Price_Lineitem extends CRM_Extendedreport_F
       + $this->getColumns('Event')
       + $this->getColumns('Participant')
       + $this->getColumns('Contribution', ['order_by' => TRUE])
+      + $this->getColumns('FirstContribution')
       + $this->getColumns('PriceField', ['order_by' => TRUE])
       + $this->getColumns('PriceFieldValue', ['order_by' => TRUE])
       + $this->getColumns('LineItem', ['order_by' => TRUE, 'fields_defaults' => ['financial_type_id', 'line_total']]) +
       $this->getColumns('BillingAddress') +
-      $this->getColumns('Address');
+      $this->getColumns('Address') +
+      $this->getColumns('Tag') +      
+      $this->getColumns('Empty');
+      $this->_groupFilter = TRUE;
     parent::__construct();
   }
 
@@ -84,6 +88,9 @@ class CRM_Extendedreport_Form_Report_Price_Lineitem extends CRM_Extendedreport_F
       'address_from_contribution',
       'email_from_contact',
       'phone_from_contact',
+      'first_from_contribution',
+      'Empty_Columns',
+      'entitytag_from_contact',
     ];
 
   }

--- a/CRM/Extendedreport/Form/Report/Price/Lineitemmembership.php
+++ b/CRM/Extendedreport/Form/Report/Price/Lineitemmembership.php
@@ -29,6 +29,7 @@ class CRM_Extendedreport_Form_Report_Price_Lineitemmembership extends CRM_Extend
     $this->_columns = $this->getColumns('Contact') +
       $this->getColumns('Membership') +
       $this->getColumns('Contribution') +
+      $this->getColumns('FirstContribution') + 
       $this->getColumns('PriceField') +
       $this->getColumns('PriceFieldValue') +
       $this->getColumns('LineItem') +
@@ -52,6 +53,8 @@ class CRM_Extendedreport_Form_Report_Price_Lineitemmembership extends CRM_Extend
       'contact_from_membership',
       'address_from_contact',
       'contribution_from_lineItem',
+      'first_from_contribution',
+      'Empty_Columns',
     ];
   }
 

--- a/CRM/Extendedreport/Form/Report/Price/Lineitemmembership.php
+++ b/CRM/Extendedreport/Form/Report/Price/Lineitemmembership.php
@@ -33,7 +33,8 @@ class CRM_Extendedreport_Form_Report_Price_Lineitemmembership extends CRM_Extend
       $this->getColumns('PriceField') +
       $this->getColumns('PriceFieldValue') +
       $this->getColumns('LineItem') +
-      $this->getColumns('Address', ['join_filters' => TRUE]);
+      $this->getColumns('Address', ['join_filters' => TRUE]) +
+      $this->getColumns('Empty');
 
     parent::__construct();
   }

--- a/CRM/Extendedreport/Form/Report/Price/Lineitemmembership.php
+++ b/CRM/Extendedreport/Form/Report/Price/Lineitemmembership.php
@@ -34,8 +34,9 @@ class CRM_Extendedreport_Form_Report_Price_Lineitemmembership extends CRM_Extend
       $this->getColumns('PriceFieldValue') +
       $this->getColumns('LineItem') +
       $this->getColumns('Address', ['join_filters' => TRUE]) +
+      $this->getColumns('Tag') +      
       $this->getColumns('Empty');
-
+      $this->_groupFilter = TRUE;
     parent::__construct();
   }
 
@@ -56,6 +57,7 @@ class CRM_Extendedreport_Form_Report_Price_Lineitemmembership extends CRM_Extend
       'contribution_from_lineItem',
       'first_from_contribution',
       'Empty_Columns',
+      'entitytag_from_contact',
     ];
   }
 


### PR DESCRIPTION
Our use case is to organize logistic for a community supported agricultue

We have to count the price items correctly. If a payment plan is active, the contributions ares splitted. This extension filters the first contribution in the payment set. Furthermore we have extend more details form the price_field table.

USE CASE: Food in the price field -> how much to deliver in the depot -> to whom