### PR TITLE
Fix relationship filter on Participant Extended Report

### DIFF
--- a/CRM/Extendedreport/Form/Report/Event/ParticipantExtended.php
+++ b/CRM/Extendedreport/Form/Report/Event/ParticipantExtended.php
@@ -116,6 +116,38 @@ class CRM_Extendedreport_Form_Report_Event_ParticipantExtended extends CRM_Exten
   }
 
   /**
+   * Overriding for the sake of handling relationship type ID.
+   */
+  function postProcess() {
+    $this->beginPostProcess();
+    $this->relationType = NULL;
+    $originalRelationshipTypes = [];
+
+    $relationships = [];
+    if ((array) $this->_params['relationship_relationship_type_id_value'] ?? FALSE) {
+      $originalRelationshipTypes = $this->_params['relationship_relationship_type_id_value'];
+      foreach ($this->_params['relationship_relationship_type_id_value'] as $relString) {
+        $relType = explode('_', $relString);
+        $this->relationType[] = $relType[1] . '_' . $relType[2];
+        $relationships[] = intval($relType[0]);
+      }
+    }
+    $this->_params['relationship_relationship_type_id_value'] = $relationships;
+    $this->buildACLClause([
+      $this->_aliases['contact_a_civicrm_contact'],
+      $this->_aliases['contact_b_civicrm_contact'],
+    ]);
+    $sql = $this->buildQuery();
+    $this->addToDeveloperTab($sql);
+    $rows = [];
+    $this->buildRows($sql, $rows);
+    $this->_params['relationship_type_id_value'] = $originalRelationshipTypes;
+    $this->formatDisplay($rows);
+    $this->doTemplateAssignment($rows);
+    $this->endPostProcess($rows);
+  }
+
+  /**
    * Declare from clauses used in the from clause for this report.
    *
    * @return array

--- a/CRM/Extendedreport/Form/Report/RelationshipExtended.php
+++ b/CRM/Extendedreport/Form/Report/RelationshipExtended.php
@@ -183,7 +183,7 @@ class CRM_Extendedreport_Form_Report_RelationshipExtended extends CRM_Extendedre
     $originalRelationshipTypes = [];
 
     $relationships = [];
-    if (CRM_Utils_Array::value('relationship_relationship_type_id_value', $this->_params) && is_array($this->_params['relationship_relationship_type_id_value'])) {
+    if ((array) $this->_params['relationship_relationship_type_id_value'] ?? FALSE) {
       $originalRelationshipTypes = $this->_params['relationship_relationship_type_id_value'];
       foreach ($this->_params['relationship_relationship_type_id_value'] as $relString) {
         $relType = explode('_', $relString);


### PR DESCRIPTION
You get a MySQL "Field Not Found" error when filtering by relationship type in the Participant Extended Report.

I cribbed the solution from the Extended Relationship Report, which must have had the same problem at some point.  I tried to be clever and solve it in `getRelationshipColumns()` but then I saw how this doesn't show both sides of a relationship and I understood why this approach was chosen.

I nevertheless updated one of the lines in the Extended Relationship report to replace a particularly gnarly `if` statement.