### PR TITLE
ensure select custom fields with multi-select enabled work

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -2330,7 +2330,7 @@ class CRM_Extendedreport_Form_Report_ExtendedReport extends CRM_Report_Form {
             'Multi-Select',
             'AdvMulti-Select',
             'CheckBox',
-          ] || $field[$htmlType] == 'Select' && $field['serialize'] == 1)
+          ] || $field['serialize'] == 1)
           ) {
             $filter['operatorType'] = CRM_Report_Form::OP_MULTISELECT_SEPARATOR;
           }
@@ -3121,7 +3121,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
           'Radio',
         ])
         ) {
-          if ($htmlType == 'Select' && $customField['serialize'] == 1) {
+          if ($customField['serialize'] == 1) {
             $value = explode(CRM_Core_DAO::VALUE_SEPARATOR, $value);
             $customData = [];
             foreach ($value as $val) {
@@ -8167,7 +8167,7 @@ WHERE cg.extends IN ('" . $extendsString . "') AND
         'Multi-Select',
         'AdvMulti-Select',
         'CheckBox',
-      ]) || ($field['html_type'] == 'Select' && $field['serialize'] == 1)) {
+      ]) || $field['serialize'] == 1) {
         $field['operatorType'] = CRM_Report_Form::OP_MULTISELECT_SEPARATOR;
       }
       else {

--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -2328,7 +2328,6 @@ class CRM_Extendedreport_Form_Report_ExtendedReport extends CRM_Report_Form {
         if (!empty($field['option_group_id'])) {
           if (in_array($htmlType, [
             'Multi-Select',
-            'AdvMulti-Select',
             'CheckBox',
           ] || $field['serialize'] == 1)
           ) {
@@ -3198,7 +3197,6 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
             break;
 
           case 'CheckBox':
-          case 'AdvMulti-Select':
           case 'Multi-Select':
             $value = explode(CRM_Core_DAO::VALUE_SEPARATOR, $value);
             $customData = [];
@@ -8165,7 +8163,6 @@ WHERE cg.extends IN ('" . $extendsString . "') AND
     if (!empty($field['option_group_id'])) {
       if (in_array($field['html_type'], [
         'Multi-Select',
-        'AdvMulti-Select',
         'CheckBox',
       ]) || $field['serialize'] == 1) {
         $field['operatorType'] = CRM_Report_Form::OP_MULTISELECT_SEPARATOR;


### PR DESCRIPTION
Without this fix, we use custom_field_x IN ('1', '2', '3')
which doesn't match custom fields with multiple values stored.

Also, those fields are not properly displayed.