### PR TITLE
ensure tag filter works on relationship report

### DIFF
--- a/CRM/Extendedreport/Form/Report/RelationshipExtended.php
+++ b/CRM/Extendedreport/Form/Report/RelationshipExtended.php
@@ -67,6 +67,31 @@ class CRM_Extendedreport_Form_Report_RelationshipExtended extends CRM_Extendedre
     parent::__construct();
   }
 
+   /**
+     * Build where clause for tags.
+     *
+     * @param string $field
+     * @param mixed $value
+     * @param string $op
+     *
+     * @return string
+     */
+    public function whereTagClause($field, $value, $op) {
+      // not using left join in query because if any contact
+      // belongs to more than one tag, results duplicate
+      // entries.
+      $sqlOp = $this->getSQLOperator($op);
+      if (!is_array($value)) {
+        $value = [$value];
+      }
+      $clause = "{$field['dbAlias']} IN (" . implode(', ', $value) . ")";
+      $entity_table = $this->_tagFilterTable;
+      return " {$this->_aliases[$entity_table]}.id {$sqlOp} (
+                            SELECT DISTINCT {$this->_aliases['civicrm_tag']}.entity_id
+                            FROM civicrm_entity_tag {$this->_aliases['civicrm_tag']}
+                            WHERE entity_table = 'civicrm_contact' AND {$clause} ) ";
+  }
+
   function from() {
     $this->setFromBase('civicrm_contact', 'id', $this->_aliases['contact_a_civicrm_contact']);
     $this->_from .= "


### PR DESCRIPTION
In the core function whereTagClause, the $entity_table value
comes from $this->_tagFilterTable.

In the RelationshipExtended report, that variable is set to:
contact_a_civicrm_contact.

This variable ends up doing double duty in this functioon.

It provides both the field name to filter on (should be
contact_a_civicrm_contact - which gets set correctly).

In addition, it also determines which value should be filtered against
in the civicrm_entity_tag table (should be civicrm_contact - woops
it's getting contact_a_civicrm_contact instead!).

In this miserable hack I'm overriding the entire function just to
hard-code "WHERE entity_table = 'civicrm_contact'". I'm sure there is a
more elegant solution, but am not sure what it is exactly. Suggestions?