### PR TITLE
allow filtering by recurring donations

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -4443,6 +4443,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
       'contribution_recur_id' => [
         'title' => ts('Recurring Contribution ID'),
         'is_fields' => TRUE,
+        'is_filters' => TRUE,
         'type' => CRM_Utils_Type::T_INT,
       ],
       'contribution_recur_id_exists' => [


### PR DESCRIPTION
This is a follow-up on #337, where I added "recurring contribution ID" as a field and "is recurring" as a pseudofield, and commented that you can't filter by pseudofields.

Despite that comment, I never added a filter by "recurring contribution ID".  Since a separate client asked for a report of recurring contributions only, I've added that filter.