### PR TITLE
Allow filtering by active event, improve display

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -4183,7 +4183,14 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
       'is_active' => [
         'title' => ts('Is Active'),
         'is_fields' => TRUE,
-        'type' => CRM_Utils_Type::T_INT,
+        'is_filters' => TRUE,
+        'type' => CRM_Utils_Type::T_BOOLEAN,
+        'operatorType' => CRM_Report_Form::OP_SELECT,
+        'options' => [
+          '' => ts('- select -'),
+          1 => ts('Yes'),
+          0 => ts('No'),
+        ],
         'crm_editable' => [
           'id_table' => 'civicrm_event',
           'id_field' => 'id',


### PR DESCRIPTION
Adds the filter in the screenshot below:
Also, before I patched I was getting `1` and `0` instead of `Yes` and `No` in my results - but only on some reports.  Maybe editable vs. non-editable?

![Selection_923](https://user-images.githubusercontent.com/1796012/93266503-278e6100-f778-11ea-8c7e-01554c902790.png)
