### PR TITLE
Fix grand totals on campaign progress report

### DIFF
--- a/CRM/Extendedreport/Form/Report/Campaign/CampaignProgressReport.php
+++ b/CRM/Extendedreport/Form/Report/Campaign/CampaignProgressReport.php
@@ -243,10 +243,10 @@ LEFT JOIN
   public function alterDisplay(&$rows) {
     parent::alterDisplay($rows);
     $this->unsetUnreliableColumnsIfNotCampaignGrouped();
-    if (isset($this->_columnHeaders['progress_still_to_raise'])) {
-      $move = $this->_columnHeaders['progress_still_to_raise'];
-      unset($this->_columnHeaders['progress_still_to_raise']);
-      $this->_columnHeaders['progress_still_to_raise'] = $move;
+    if (isset($this->_columnHeaders['progress_progress_still_to_raise'])) {
+      $move = $this->_columnHeaders['progress_progress_still_to_raise'];
+      unset($this->_columnHeaders['progress_progress_still_to_raise']);
+      $this->_columnHeaders['progress_progress_still_to_raise'] = $move;
     }
 
     $runningTotalGoal = $runningTotalLeft = 0;
@@ -254,13 +254,13 @@ LEFT JOIN
     foreach ($rows as $index => $row) {
       if (isset($row['civicrm_campaign_campaign_goal_revenue']) && is_numeric($row['civicrm_campaign_campaign_goal_revenue'])) {
         $runningTotalGoal += $row['civicrm_campaign_campaign_goal_revenue'];
-        if (isset($row['progress_still_to_raise']) && is_numeric($row['progress_still_to_raise'])) {
-          $runningTotalLeft += $row['progress_still_to_raise'];
+        if (isset($row['progress_progress_still_to_raise']) && is_numeric($row['progress_progress_still_to_raise'])) {
+          $runningTotalLeft += $row['progress_progress_still_to_raise'];
         }
       }
       else {
         $rows[$index]['civicrm_campaign_campaign_goal_revenue'] = $runningTotalGoal;
-        $rows[$index]['progress_still_to_raise'] = $runningTotalLeft;
+        $rows[$index]['progress_progress_still_to_raise'] = $runningTotalLeft;
         $grandTotalLeft += $runningTotalLeft;
         $grandTotalGoal += $runningTotalGoal;
         $runningTotalGoal = $runningTotalLeft = 0;
@@ -272,8 +272,10 @@ LEFT JOIN
       }
 
     }
+    $grandTotalLeft += $runningTotalLeft;
+    $grandTotalGoal += $runningTotalGoal;
     $this->rollupRow['civicrm_campaign_campaign_goal_revenue'] = $grandTotalGoal;
-    $this->rollupRow['progress_still_to_raise'] = $grandTotalLeft;
+    $this->rollupRow['progress_progress_still_to_raise'] = $grandTotalLeft;
     $this->assign('grandStat', $this->rollupRow);
   }
 


### PR DESCRIPTION
Campaign Progress Report doesn't create totals for two reasons:
* One of the field names has changed (`progress_still_to_raise` to `progress_progress_still_to_raise`).
* It doesn't add in any values past the last subtotal.  Which is fine if you're grouping with subtotals, otherwise you get zeroes.

Note also that the redacted campaign names in the screenshots below are links to the Contribution Detail Report.  I left those in a separate extension because they link to the non-Extended Report version (Extended Report Contribution Details doesn't support campaigns).  Let me know if I should PR those also.

##### Before
![Selection_935](https://user-images.githubusercontent.com/1796012/94317490-76947d00-ff54-11ea-8dda-d43cc1c5cdb6.png)

##### After
![Selection_934](https://user-images.githubusercontent.com/1796012/94317501-7c8a5e00-ff54-11ea-8f9c-2b3d82a2ad24.png)
