### PR TITLE
Add pay later as a filter in reports

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -4459,6 +4459,16 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'default' => NULL,
         'type' => CRM_Utils_Type::T_STRING,
       ],
+      'is_pay_later' => [
+        'is_fields' => FALSE,
+        'is_filters' => TRUE,
+        'is_order_bys' => FALSE,
+        'title' => 'Is Pay Later?',
+        'operatorType' => CRM_Report_Form::OP_SELECT,
+        'options' => ['' => '--select--'] + CRM_Contribute_BAO_Contribution::buildOptions('is_pay_later'),
+        'default' => NULL,
+        'type' => CRM_Utils_Type::T_STRING,
+      ],
       'contact_id' => [
         'title' => ts('Contribution Contact ID'),
         'name' => 'contact_id',


### PR DESCRIPTION
Any reason why this isn't included by default in the reports? Seems to be v helpful in creating a report for incomplete transaction in last week/month with -

Status = Pending.
Is Pay later = No.

Screenshot of detailextended report after the PR -

![image](https://user-images.githubusercontent.com/5929648/96689222-bc036900-139f-11eb-91f7-7bc124610985.png)
