### PR TITLE
Fix PHPUnit8 Warnings

### DIFF
--- a/tests/phpunit/ActivityExtendedTest.php
+++ b/tests/phpunit/ActivityExtendedTest.php
@@ -33,7 +33,7 @@ class ActivityExtendedTest extends BaseTestClass implements HeadlessInterface, H
       'activity_activity_date_time_relative' => 'previous.month',
     ];
     $this->getRows($params);
-    $this->assertContains('235959', $this->sql[0]);
+    $this->assertStringContainsString('235959', $this->sql[0]);
   }
 
   /**

--- a/tests/phpunit/ActivityPivotTest.php
+++ b/tests/phpunit/ActivityPivotTest.php
@@ -42,7 +42,7 @@ class ActivityPivotTest extends BaseTestClass implements HeadlessInterface, Hook
     $completedStatusID = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'status_id', 'Completed');
     $scheduledStatusID = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'status_id', 'Scheduled');
     $rows = $this->getRows($params);
-    $this->assertContains('SUM( CASE', $this->sql[0]);
+    $this->assertStringContainsString('SUM( CASE', $this->sql[0]);
     $this->assertEquals('Meeting', $rows[0]['civicrm_activity_activity_activity_type_id']);
     $this->assertEquals(2, $rows[0]['status_id_total']);
     $this->assertEquals(1, $rows[0]['status_id_' . $completedStatusID]);


### PR DESCRIPTION
This fixes these 2 warnings

ok 1 - # Warning Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
ok 2 - ActivityExtendedTest::testCidFilter
ok 3 - # Warning Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.