### PR TITLE
Show grand total for 'Total Received' on Campaign Report

### DIFF
--- a/CRM/Extendedreport/Form/Report/Campaign/CampaignProgressReport.php
+++ b/CRM/Extendedreport/Form/Report/Campaign/CampaignProgressReport.php
@@ -249,20 +249,25 @@ LEFT JOIN
       $this->_columnHeaders['progress_progress_still_to_raise'] = $move;
     }
 
-    $runningTotalGoal = $runningTotalLeft = 0;
-    $grandTotalGoal = $grandTotalLeft = 0;
+    $runningTotalGoal = $runningTotalLeft = $runningTotalReceived = 0;
+    $grandTotalGoal = $grandTotalLeft = $grandTotalReceived = 0;
     foreach ($rows as $index => $row) {
       if (isset($row['civicrm_campaign_campaign_goal_revenue']) && is_numeric($row['civicrm_campaign_campaign_goal_revenue'])) {
         $runningTotalGoal += $row['civicrm_campaign_campaign_goal_revenue'];
         if (isset($row['progress_progress_still_to_raise']) && is_numeric($row['progress_progress_still_to_raise'])) {
           $runningTotalLeft += $row['progress_progress_still_to_raise'];
         }
+        if (isset($row['progress_progress_paid_amount_sum']) && is_numeric($row['progress_progress_paid_amount_sum'])) {
+          $runningTotalReceived += $row['progress_progress_paid_amount_sum'];
+        }
       }
       else {
         $rows[$index]['civicrm_campaign_campaign_goal_revenue'] = $runningTotalGoal;
         $rows[$index]['progress_progress_still_to_raise'] = $runningTotalLeft;
+        $rows[$index]['progress_progress_paid_amount_sum'] = $runningTotalReceived;
         $grandTotalLeft += $runningTotalLeft;
         $grandTotalGoal += $runningTotalGoal;
+        $grandTotalReceived += $runningTotalReceived;
         $runningTotalGoal = $runningTotalLeft = 0;
         foreach ($rows[$index] as $field => $value) {
           if (is_numeric($value)) {
@@ -274,8 +279,10 @@ LEFT JOIN
     }
     $grandTotalLeft += $runningTotalLeft;
     $grandTotalGoal += $runningTotalGoal;
+    $grandTotalReceived += $runningTotalReceived;
     $this->rollupRow['civicrm_campaign_campaign_goal_revenue'] = $grandTotalGoal;
     $this->rollupRow['progress_progress_still_to_raise'] = $grandTotalLeft;
+    $this->rollupRow['progress_progress_paid_amount_sum'] = $grandTotalReceived;
     $this->assign('grandStat', $this->rollupRow);
   }
 


### PR DESCRIPTION
The Campaign Progress report shows grand totals for "Goal" and "Amount Left" but not for the total received.

### Before
![Selection_1375](https://user-images.githubusercontent.com/1796012/152595493-d45ef7fe-95c0-4747-96d8-54e4c0030a4e.png)

### After
![Selection_1376](https://user-images.githubusercontent.com/1796012/152595505-9a9f0615-286f-4b35-8b0c-b9ec454988e3.png)

