### PR TITLE
show campaign names even if completed

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -6398,7 +6398,7 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
    * @return array
    */
   function alterCampaign($value, &$row) {
-    $campaigns = CRM_Campaign_BAO_Campaign::getCampaigns();
+    $campaigns = CRM_Campaign_BAO_Campaign::getCampaigns(NULL, NULL, FALSE, FALSE, FALSE, TRUE);
     return CRM_Utils_Array::value($value, $campaigns);
   }
 


### PR DESCRIPTION
I've never seen this report in 12 years of Civi, then 2 different clients report issues in one week.

`CRM_Campaign_BAO_Campaign::getCampaigns()` by default will only return current campaigns (i.e. they have an end date in the past).  This results in some names not showing up on the Campaign Progress Report, this PR returns all campaign names.