### PR TITLE
Return correct value for Grant managed entity when grant extension not installed

### DIFF
--- a/CRM/Extendedreport/Form/Report/Grant/Detail.mgd.php
+++ b/CRM/Extendedreport/Form/Report/Grant/Detail.mgd.php
@@ -5,7 +5,7 @@ $civiGrant = civicrm_api3('Extension', 'get', [
 ]);
 
 if (empty($civiGrant['values'])) {
-  return;
+  return [];
 }
 // This file declares a managed database record of type "ReportTemplate".
 // The record will be automatically inserted, updated, or deleted from the


### PR DESCRIPTION
Otherwise you get a php notice whenever civi reconciles managed entities.