### PR TITLE
also get label for transaction status column

### DIFF
--- a/CRM/Extendedreport/Form/Report/Contribute/BookkeepingExtended.php
+++ b/CRM/Extendedreport/Form/Report/Contribute/BookkeepingExtended.php
@@ -339,6 +339,9 @@ class CRM_Extendedreport_Form_Report_Contribute_BookkeepingExtended extends CRM_
       if ($value = CRM_Utils_Array::value('civicrm_contribution_contribution_status_id', $row)) {
         $rows[$rowNum]['civicrm_contribution_contribution_status_id'] = CRM_Core_PseudoConstant::getLabel('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $value);
       }
+      if ($value = CRM_Utils_Array::value('civicrm_financial_trxn_financial_trxn_financial_trxn_status_id', $row)) {
+        $rows[$rowNum]['civicrm_financial_trxn_financial_trxn_financial_trxn_status_id'] = CRM_Core_PseudoConstant::getLabel('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $value);
+      }
 
       // handle financial type id
       if ($value = CRM_Utils_Array::value('civicrm_line_item_financial_type_id', $row)) {
@@ -376,4 +379,3 @@ class CRM_Extendedreport_Form_Report_Contribute_BookkeepingExtended extends CRM_
   }
 
 }
-


### PR DESCRIPTION
Get status labels for Financial Trxn > Transaction Status column like we do for the contribution status column.

Before: Transaction Status column outputs a status ID i.e. "7"
After: Transaction Status column outputs a status label i.e. "Refunded"