### PR TITLE
fix error when  `$var` is null when running "Extended Report - Participants"

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -2706,6 +2706,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
             $criteriaQueryParams = CRM_Report_Utils_Report::getPreviewCriteriaQueryParams($this->_defaults, $this->_params);
             $groupByCriteria = $this->getGroupByCriteria($tableCol, $row);
 
+            $val = ($val == NULL) ? '' : $val;
             $url = CRM_Report_Utils_Report::getNextUrl($baseUrl,
               "reset=1&force=1&$criteriaQueryParams&" .
               $fieldName . "_op=in&{$fieldName}_value=" . $this->commaSeparateCustomValues($val) . $groupByCriteria,


### PR DESCRIPTION
Fixes: `PHP Fatal error:  Uncaught TypeError: Argument 1 passed to CRM_Extendedreport_Form_Report_ExtendedReport::commaSeparateCustomValues() must be of the type string, null given` when running a report powered by the template: `Extended Report - Participants`