### PR TITLE
Handle comma separated $value

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -6322,6 +6322,21 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
    *   Event label.
    */
   protected function alterEventType($value): string {
+    // Check if $value is comma separated.
+    $separator = ',';
+    if (strpos($value, $separator) !== FALSE) {
+      // If yes, convert to array.
+      $valueArr = explode($separator, $value);
+      // Iterate through the array.
+      foreach ($valueArr as $value) {
+        // Look up the event type for each $value.
+        $eventTypeArr[] = CRM_Event_PseudoConstant::eventType($value);
+        // Then set the $value to a comma-space separated string of event types.
+        $value = implode(', ', $eventTypeArr);
+      }
+      return $value;
+    }
+    // If not comma separated, just look up single event type.    
     return $value ? CRM_Event_PseudoConstant::eventType($value) : '';
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Currently, this extension does not handle the situation in which a user has a multi value, searchable custom field on Events and then wants to use that custom field as a grouping option within a CiviReport that uses the Extended Report - Editable event Grid - Template.

Before
----------------------------------------
If a user has a multi value, searchable custom field on Events and then attempts to use the Extended Report - Editable event Grid - Template report and group by that custom field, they encounter a fatal error on their site instead of receiving the report's results

**Replication Steps**
1. Create a set of custom fields Used For **Events**
1. Create a field for that set that has an Alphanumeric Data Type, is Multi-Select enabled, and Is this Field Searchable? is checked. Create at least two multiple choice options 
1. Create an Event that has at least two values for that custom field. 
1. Go to **Reports > All Reports**, click on **New Report** and select **Extended Report - Editable event Grid**
1. On the *Columns* tab, select (at a minimum) **Event Title**
1. On the *Grouping* tab, select the custom field.
1. Click **Refresh results**

This will trigger the following (fatal) error: 
`TypeError: Return value of CRM_Extendedreport_Form_Report_ExtendedReport::alterEventType() must be of the type string, null returned in CRM_Extendedreport_Form_Report_ExtendedReport->alterEventType() (line 6324 of /home/brienne/buildkit/build/dmaster/web/sites/default/files/civicrm/ext/nz.co.fuzion.extendedreport/CRM/Extendedreport/Form/Report/ExtendedReport.php).`

![Selection_163](https://user-images.githubusercontent.com/87245718/206800864-4f64666f-f7ee-4c76-b985-cec99cb3b5c0.png)


After
----------------------------------------
With this PR, the `alterEventType()` function checks to see if `$value` contains any commas, which would indicate that there is more than one value. If the variable does contain at least one comma, then an array is created out of `$value` and that array is iterated through to retrieve the event types. Then, `$value` is restored to a string that contains all of the custom field's values, separated by a comma.

With that change, a user is able to group by the custom field without receiving an error if they have events with multiple values.

![Selection_164](https://user-images.githubusercontent.com/87245718/206800885-dd6be450-5491-43cd-a03b-a75b37b41b42.png)


Technical Details
----------------------------------------
`CRM_Event_PseudoConstant::eventType($value)` expects an integer but `alterEventType($value)` does not always pass an integer. 