### PR TITLE
Comma separated $value for Pivot table

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -2589,7 +2589,20 @@ LEFT JOIN civicrm_contact {$prop['alias']} ON {$prop['alias']}.id = {$this->_ali
       return '';
     }
     $value = trim(($value ?? ''), CRM_Core_DAO::VALUE_SEPARATOR);
-    return (string) ($this->getCustomFieldOptions($specs)[$value] ?? $value);
+    // Convert $value, which is a string, to an array, passing in the VALUE_SEPARATOR.
+    $valueArr = explode(CRM_Core_DAO::VALUE_SEPARATOR, $value);
+    $options = $this->getCustomFieldOptions($specs);
+    $optionsArr = [];
+    // Loop through the array and check if $value is a key in $options.
+    foreach ($valueArr as $value) {
+      if (array_key_exists($value, $options)) {
+        // If it is, append the value of the option with a key of $value to an array.
+        $optionsArr[] = $options[$value];
+      }
+    }
+    // Convert the array of options into a comma separated string.
+    $value = implode(', ', $optionsArr);
+    return $value;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Currently, this extension does not handle the situation in which a user has a multi value, custom field that they pass into the **Select Row Fields** option on the *Pivot table* tab of a report.

Before
----------------------------------------
If a user has a multi value, custom field and selects that field to create a report with a Pivot table, (such as when using the CRM_Extendedreport_Form_Report_Event_EventPivot class), the label of those custom options is not returned. Instead, the column is populated with a non-separated integer of the options' values.

![Selection_172](https://user-images.githubusercontent.com/87245718/209696724-3ef02ea3-f743-42f8-9746-66ce73651bf4.png)

**Replication Steps**
1. Create a set of custom fields Used For **Events**
1. Create a field for that set that has an Alphanumeric Data Type and is Multi-Select enabled. Create at least two multiple choice options.
1. Create an Event that has at least two values for that custom field. 
1. Go to **Reports > All Reports**, click on **New Report** and select **Extended Report - Event Pivot Chart**
1. On the **Pivot table** tab, select the custom field from the drop down next to **Select Row Fields**.
1. Click **Refresh results**

![Selection_174](https://user-images.githubusercontent.com/87245718/209696673-19639e58-30f8-49ca-ae75-64b8bb3907ca.png)


After
----------------------------------------
With this PR, the pivot table displays the comma separated labels of the selected custom field.

![Selection_173](https://user-images.githubusercontent.com/87245718/209696702-67c5da26-6686-410b-887d-dc3854477694.png)

Technical Details
----------------------------------------
To return the custom fields' labels instead of their values, `alterFromOptions()` has been modified to first convert `$value`, which starts as a string, into to an array (`$valueArr`).  The custom options are then retrieved by calling `$this->getCustomFieldOptions($specs)`.  Then, `$valueArr` is looped through and if `$value` is a key in `$options`,  the value of the array item is appended to `$optionsArr` with a key of that `$value`. Finally, the array of options is converted into a comma separated string and returned.