### PR TITLE
Set Main Page and Documentation URLs in info.xml

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -5,7 +5,8 @@
   <description>Extended reports</description>
   <license>AGPL</license>
   <urls>
-    <url desc="Main Extension Page">http://civicrm.org</url>
+    <url desc="Main Extension Page">https://github.com/eileenmcnaughton/nz.co.fuzion.extendedreport</url>
+    <url desc="Documentation">https://github.com/eileenmcnaughton/nz.co.fuzion.extendedreport</url>
     <url desc="Support">http://chat.civicrm.org</url>
     <url desc="Licensing">http://civicrm.org/licensing</url>
   </urls>


### PR DESCRIPTION
Hi Eileen, setting these URLs (well, at least the Main Extension Page) is helpful to me when I inspect an instance’s extensions list and want to know what a new release has to offer, and perhaps decide to update to a version that is not the most recent one. Since I use this extension on a few instances, here is a PR. I didn’t go through all your extensions, this issue might exist in others.