### PR TITLE
Don't crash when contribution page is selected as a column

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -6314,10 +6314,10 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
   /**
    * @param $value
    *
-   * @return array|null
+   * @return string
    */
-  protected function alterContributionPage($value): ?array {
-    return CRM_Contribute_PseudoConstant::contributionPage($value);
+  protected function alterContributionPage($value): string {
+    return $value === NULL ? '' : (CRM_Contribute_PseudoConstant::contributionPage($value) ?? '');
   }
 
   /**


### PR DESCRIPTION
1. Pick `Contribution Page` as one of the columns.
2. Type Error crash if there are any contributions that come from a contribution page.
 
A couple things:

* This function alters the display value for a column in the report. Returning array makes no sense. Should be string, possibly null but '' makes more sense than null.
* The [commit that caused this](https://github.com/eileenmcnaughton/nz.co.fuzion.extendedreport/commit/74000702af3bd72cc399743ba50e5853e1e0eed9#diff-c34fee0ab5c796af0f8614fb9d77aa0f70116ebde4360e5f0f1b630a35d5c6bcL6412) I assume was some phpstorm-suggested mass-replace based on docblocks.
  * The [docblock in core](https://github.com/civicrm/civicrm-core/blob/039f856be0ac19e7ed9fa7b0f62d0e9c8f829875/CRM/Contribute/PseudoConstant.php#L176) is wrong. It's another of those functions that returns an array or string depending on the param. I'll make a separate PR in core for that.
  * That function is deprecated, but `title` is not a valid field for buildOptions for contribution pages (returns FALSE), so it's not really deprecated and I can't replace this call here with a call to buildOptions.