### PR TITLE
Fix warning if CiviCampaign is not enabled.

### DIFF
--- a/CRM/Extendedreport/Form/Report/Campaign/CampaignProgressReport.mgd.php
+++ b/CRM/Extendedreport/Form/Report/Campaign/CampaignProgressReport.mgd.php
@@ -23,3 +23,6 @@ if (CRM_Core_Component::isEnabled('CiviCampaign')) {
     ],
   ];
 }
+else {
+  return [];
+}


### PR DESCRIPTION
Without this: 'Warning: Invalid argument supplied for foreach() in /home/meldcrm/www/www/wp-content/plugins/civicrm/civicrm/mixin/mgd-php@1/mixin.php on line 37' on cache clear.