### PR TITLE
fixes#538: fix tabset error on 'Manage Events' page

### DIFF
--- a/extendedreport.php
+++ b/extendedreport.php
@@ -41,6 +41,9 @@ function extendedreport_version_at_least($version) {
 }
 
 function extendedreport_civicrm_tabset($tabsetName, &$tabs, $context) {
+  if (!isset($context['contact_id'])) {
+    return;
+  }
   $reports = civicrm_api3('ReportInstance', 'get', ['form_values' => ['LIKE' => '%contact_dashboard_tab";s:1:"1";%']]);
 
   foreach ($reports['values'] as $report) {


### PR DESCRIPTION
Tagging @colemanw in case he submitted PRs similar to #529 on other extensions.

`hook_civicrm_tabset` is used to control the tabs on a contact page, but also the action links in many search results (e.g. "Manage Events").  The `$context` variable assists in distinguishing, which I'm doing here.

Since Afforms as contact tabs always have a contact ID, this shouldn't introduce any new problems.