### PR TITLE
Fix support for editing tabs in ContactLayout extension

### DIFF
--- a/extendedreport.php
+++ b/extendedreport.php
@@ -41,7 +41,7 @@ function extendedreport_version_at_least($version) {
 }
 
 function extendedreport_civicrm_tabset($tabsetName, &$tabs, $context) {
-  if (!isset($context['contact_id'])) {
+  if ($tabsetName !== 'civicrm/contact/view') {
     return;
   }
   $reports = civicrm_api3('ReportInstance', 'get', ['form_values' => ['LIKE' => '%contact_dashboard_tab";s:1:"1";%']]);


### PR DESCRIPTION
#545 fixed the tab showing up outside the contact summary screen, but at the expense of ContactLayout which passes `null` for `$context['contact_id']`. This fixes it to still only show up on the contact summary screen, but now works with ContactLayout.

FYI @MegaphoneJon 