### PR TITLE
Fix typeerror with pivot report

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -960,9 +960,9 @@ class CRM_Extendedreport_Form_Report_ExtendedReport extends CRM_Report_Form {
    *   Array containing the name descriptors we have.
    *   If a value is found it will be added to the spec.
    *
-   * @return string
+   * @return string|array
    */
-  protected function getFilterFieldValue(array &$spec): string {
+  protected function getFilterFieldValue(array &$spec): string|array {
     $fieldName = $spec['table_name'] . '_' . $spec['name'];
     $valueKey = $fieldName . '_value';
     if (isset($this->_params[$valueKey])) {


### PR DESCRIPTION
## Overview
This pull request (PR) addresses the `TypeError` that occurs when viewing a pivot report result.

## Before
![21211hello](https://github.com/eileenmcnaughton/nz.co.fuzion.extendedreport/assets/85277674/12587e1d-13d2-44a5-84f7-5885918d3116)

On CiviCRM DMaster
![11WQER](https://github.com/eileenmcnaughton/nz.co.fuzion.extendedreport/assets/85277674/3e0f10d5-680f-4f93-a49c-84cafc785a6b)

## After
![31211hello](https://github.com/eileenmcnaughton/nz.co.fuzion.extendedreport/assets/85277674/e4634691-0d48-4caf-ad7c-731e34cf00ac)

## Technical Overview
```
TypeError: Return value of CRM_Extendedreport_Form_Report_ExtendedReport::getFilterFieldValue() must be of the type string, array returned in CRM_Extendedreport_Form_Report_ExtendedReport->getFilterFieldValue() (line 971 of /srv/buildkit/build/dmaster/web/sites/default/files/civicrm/ext/nz.co.fuzion.extendedreport/CRM/Extendedreport/Form/Report/ExtendedReport.php).
```

This error occurs because the `getFilterFieldValue` function assumes that the filter fields are only text (i.e., string), but some filter fields are actually select fields (i.e., arrays).
