### PR TITLE
Ensure return type has PHP7 support

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -962,7 +962,7 @@ class CRM_Extendedreport_Form_Report_ExtendedReport extends CRM_Report_Form {
    *
    * @return string|array
    */
-  protected function getFilterFieldValue(array &$spec): string|array {
+  protected function getFilterFieldValue(array &$spec) {
     $fieldName = $spec['table_name'] . '_' . $spec['name'];
     $valueKey = $fieldName . '_value';
     if (isset($this->_params[$valueKey])) {


### PR DESCRIPTION
## Overview
As a Follow up to this [PR](https://github.com/eileenmcnaughton/nz.co.fuzion.extendedreport/pull/556) ensure the change introduces works with the older version of PHP.
