### PR TITLE
Respect filter values when displaying aggregate result

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -892,14 +892,9 @@ class CRM_Extendedreport_Form_Report_ExtendedReport extends CRM_Report_Form {
       $options['values'] = array_intersect_key($options, array_flip($this->_params[$fieldName . '_value']));
     }
 
-    $filterSpec = [
-      'field' => ['name' => $fieldName],
-      'table' => ['alias' => $spec['table_name']],
-    ];
-
     // for now we will literally just handle IN
-    if ($this->getFilterFieldValue($spec) && $filterSpec['field']['op'] === 'in') {
-      $options = array_intersect_key($options, array_flip($filterSpec['field']['value']));
+    if ($this->getFilterFieldValue($spec) && $spec['field']['op'] === 'in') {
+      $options = array_intersect_key($options, array_flip($spec['field']['value']));
       $this->_aggregatesIncludeNULL = FALSE;
     }
 


### PR DESCRIPTION
## Overview
This pull request (PR) ensures that the aggregate report columns adhere to the conditions specified in the filter columns. For example, if an aggregate report uses a Contact Type field as the column header and applies a filter to only include Contact Types of 'Individual' and 'Household', the resulting column headers should not include any other Contact Types.

## Before
The aggregate report does not respect the filter field when displaying the column headers.
![65431211hello](https://github.com/eileenmcnaughton/nz.co.fuzion.extendedreport/assets/85277674/505e3eab-f7c1-4025-8253-7976bf6e4d5a)


## After
The aggregate report now respects the filter field when displaying the column headers.
![431211hello](https://github.com/eileenmcnaughton/nz.co.fuzion.extendedreport/assets/85277674/7d3ba82c-2c18-4875-8558-fef29a9d1218)