### PR TITLE
alterCustoDataDisplay is called by the parent

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -2363,8 +2363,6 @@ LEFT JOIN civicrm_contact {$prop['alias']} ON {$prop['alias']}.id = {$this->_ali
       $pager = FALSE;
     }
     parent::formatDisplay($rows, $pager);
-    // use this method for formatting custom rows for display purpose.
-    $this->alterCustomDataDisplay($rows);
   }
 
   /**


### PR DESCRIPTION
And when called twice, the second time it gets the label of multi value fields instead of the id and then those end up blank.