### PR TITLE
Fix array to string notice error on test fail

### DIFF
--- a/tests/phpunit/Civi/Extendedreport/Contribute/ContributionContributionsTest.php
+++ b/tests/phpunit/Civi/Extendedreport/Contribute/ContributionContributionsTest.php
@@ -224,7 +224,7 @@ class ContributionContributionsTest extends BaseTestClass {
         'contact_note_note' => '1',
       ]
     ]);
-    $this->assertCount(2, $rows, $this->sql . "\n" . print_r($rows, TRUE));
+    $this->assertCount(2, $rows, print_r($this->sql) . "\n" . print_r($rows, TRUE));
     $this->assertEquals('first note, second note', $rows[0]['contribution_civicrm_note_contribution_note_note']);
     $this->assertEquals('first contact note, second contact note', $rows[0]['contact_civicrm_note_contact_note_note']);
 


### PR DESCRIPTION
Thi fixes the notice error found by Jenkins but it suggests the test fails here @eileenmcnaughton 