### PR TITLE
allow selection of past campaigns as long as they are active

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -4044,7 +4044,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'title' => ts('Campaign'),
         'type' => CRM_Utils_Type::T_INT,
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
-        'options' => CRM_Campaign_BAO_Campaign::getCampaigns(),
+        'options' => CRM_Campaign_BAO_Campaign::getCampaigns(NULL, NULL, TRUE, FALSE),
         'is_fields' => TRUE,
         'is_filters' => TRUE,
         'is_order_bys' => TRUE,


### PR DESCRIPTION
It seems that the campaigns list includes past campaigns in other places in this extension, so this makes it more consistent.