### PR TITLE
Fix a couple of notice errors when sending report on cron

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -1977,7 +1977,7 @@ class CRM_Extendedreport_Form_Report_ExtendedReport extends CRM_Report_Form {
     if (in_array($this->_outputMode, [
         'print',
         'pdf'
-      ]) && $this->_params['templates']) {
+      ]) && array_key_exists('templates', $this->_params) && $this->_params['templates']) {
         $defaultTpl = 'CRM/Extendedreport/Form/Report/CustomTemplates/' . $this->_params['templates'] . '.tpl';
       }
 
@@ -4696,6 +4696,10 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
       $join = $this->getQillForField($field, $fieldName, 'join_filter_');
       $join['title'] = E::ts('%1 only included based on filter ', [$field['entity']]) . $join['title'];
       $statistics['filters'][] = $join;
+    }
+    // Prevents an e-notice in Statistics.tpl
+    if (!isset($statistics['filters'])) {
+      $statistics['filters'] = [];
     }
   }
 


### PR DESCRIPTION
This fixes the following PHP warning notices when sending reports on cron

```
[PHP Warning] Undefined array key "templates" at /<client site>/nz.co.fuzion.extendedreport/CRM/Extendedreport/Form/Report/ExtendedReport.php:1980
[PHP Warning] Undefined array key "filters" at /<client site>/wp-content/uploads/civicrm/templates_c/en_US/2c/10/c8/2c10c87a1d66c731b76ea6a1d02c161e0ac39ee8_0.file.Statistics.tpl.php:56
```