### PR TITLE
avoid error when payment instrument is comma separated values

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -6480,9 +6480,18 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
    *
    * @return string
    */
-  protected function alterPaymentType(?int $value): string {
+  protected function alterPaymentType(?string $value): string {
     $paymentInstruments = CRM_Contribute_BAO_Contribution::buildOptions('payment_instrument_id', 'get');
-    return (string) ($paymentInstruments[$value] ?? '');
+    $values = explode(',', $value);
+    $labels = [];
+    foreach ($values as $value) {
+      $label = $paymentInstruments[$value] ?? '';
+      if ($label) {
+        $labels[] = $label;
+      }
+    }
+        
+    return (string) implode(',', $labels);
   }
 
   /**


### PR DESCRIPTION
On at least one report, I'm getting the following error:

> TypeError: CRM_Extendedreport_Form_Report_ExtendedReport::alterPaymentType(): Argument #1 ($value) must be of type ?int, string given, called in /var/www/powerbase/sites/all/modules/civicrm/CRM/Report/Form.php on line 2579 in CRM_Extendedreport_Form_Report_ExtendedReport->alterPaymentType() (line 6479 of /var/www/powerbase/sites/all/extensions/extendedreport/CRM/Extendedreport/Form/Report/ExtendedReport.php).

I don't think it's a data problem (but could be?). I did manage to fix it with this change. The value seems to be coming in either as a numeric string or a comma separated list of numbers (which seems to be what triggered the error).