### PR TITLE
Fix grand total display for pivot reports

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -2491,9 +2491,11 @@ LEFT JOIN civicrm_contact {$prop['alias']} ON {$prop['alias']}.id = {$this->_ali
     $altered = [];
     $fieldsToUnSetForSubtotalLines = [];
     //on this first round we'll get a list of keys that are not groupbys or stats
-    foreach (array_keys($firstRow) as $rowField) {
-      if (!array_key_exists($rowField, $groupBys) && substr($rowField, -4) !== '_sum' && !substr($rowField, -7) !== '_count') {
-        $fieldsToUnSetForSubtotalLines[] = $rowField;
+    if (!$this->isPivot) {
+      foreach (array_keys($firstRow) as $rowField) {
+        if (!array_key_exists($rowField, $groupBys) && substr($rowField, -4) !== '_sum' && !substr($rowField, -7) !== '_count') {
+          $fieldsToUnSetForSubtotalLines[] = $rowField;
+        }
       }
     }
 
@@ -5730,13 +5732,13 @@ AND {$this->_aliases['civicrm_line_item']}.entity_table = 'civicrm_participant')
    * Define join from Participant to Contribution table
    */
   protected function joinContributionFromParticipant(): void {
-    if ($this->isTableSelected('civicrm_contribution')) {   
+    if ($this->isTableSelected('civicrm_contribution')) {
       $this->_from .= " LEFT JOIN civicrm_participant_payment pp
 ON {$this->_aliases['civicrm_participant']}.id = pp.participant_id
 LEFT JOIN civicrm_contribution {$this->_aliases['civicrm_contribution']}
 ON pp.contribution_id = {$this->_aliases['civicrm_contribution']}.id
 ";
-    }  
+    }
   }
 
   /**
@@ -6492,7 +6494,7 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
         $labels[] = $label;
       }
     }
-        
+
     return (string) implode(',', $labels);
   }
 


### PR DESCRIPTION
Grand total is missing from Pivot reports

To replicate: Create a report from ` Extended Report - Pivot data contact report` template
Row Field: Contact Type
Column: Is Deceased

**Before**

![image](https://github.com/user-attachments/assets/df2d9c0f-3bb9-4348-a4de-b5f22f93a10d)

**After**

![image](https://github.com/user-attachments/assets/99330574-5886-4aa0-b402-27e68a40c97a)