### PR TITLE
Fatal error when alterGenderID fn cannot accept comma separated integer argument

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -6403,12 +6403,22 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
   }
 
   /**
-   * @param int|null $value
+   * @param string|null $value
    *
    * @return string
    */
-  protected function alterGenderID(?int $value): string {
-    return CRM_Contact_BAO_Contact::buildOptions('gender_id')[$value] ?? '';
+  protected function alterGenderID(?string $value): string {
+    $genders = CRM_Contact_BAO_Contact::buildOptions('gender_id');
+
+    if (CRM_Utils_Type::validate($value, 'CommaSeparatedIntegers', FALSE)) {
+      $value = explode(',', $value);
+    }
+
+    foreach ((array) $value as $key => $genderID) {
+      $value[$key] = $genders[trim($genderID)] ?? '';
+    }
+
+    return implode(', ', $value);
   }
 
   /**


### PR DESCRIPTION
This is a fix for #587 . Error occured for rollup last row that passes comma separated gender IDs to CRM_Extendedreport_Form_Report_ExtendedReport::alterGenderID() that ends up with a typeError. I followed the same approach as of https://github.com/eileenmcnaughton/nz.co.fuzion.extendedreport/pulls?q=type+error+ 


