### PR TITLE
ensure boolean custom data values are displayed properly

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -2648,6 +2648,9 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
           if ($customField['data_type'] === 'Money') {
             $rows[$rowNum][$tableCol] = $val;
           }
+          else if ($customField['data_type'] === 'Boolean') {
+            $rows[$rowNum][$tableCol] = $val;
+          }
           else {
             $rows[$rowNum][$tableCol] = CRM_Core_BAO_CustomField::displayValue($val, $customField['id']);
           }


### PR DESCRIPTION
The values is already "Yes" or "No" at this point, so fetching the value via `displayValue` always returns an empty string. 