### PR TITLE
Ensure group selectors render correctly

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -386,7 +386,7 @@ class CRM_Extendedreport_Form_Report_ExtendedReport extends CRM_Report_Form {
           'type' => CRM_Utils_Type::T_INT,
           'operatorType' => CRM_Report_Form::OP_MULTISELECT,
           'group' => TRUE,
-          'options' => CRM_Core_PseudoConstant::nestedGroup(),
+          'options' => CRM_Core_PseudoConstant::nestedGroup(TRUE, NULL, TRUE, "plain"),
           'alias' => 'civicrm_group_gid',
           'is_filters' => TRUE,
           'is_fields' => FALSE,


### PR DESCRIPTION
In 6.13 select dropdowns always escape html which causes group selectors to look bad.
This passes the new to param to format the group hierarchy in a plain text compatible format.

This change is backward-compatible; in CiviCRM < 6.13 the new param will be ignored.